### PR TITLE
bug: Remove extraneous handle in ctx generation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thruster"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Pete Mertz <peter.s.mertz@gmail.com>"]
 description = "A middleware based http async web server."
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ lazy_static! {
   };
 }
 
-fn generate_context(request: &Request, _handle: &Handle) -> Ctx {
+fn generate_context(request: &Request) -> Ctx {
   Ctx {
     body: "".to_owned(),
     params: request.params().clone()

--- a/examples/hello_world/context.rs
+++ b/examples/hello_world/context.rs
@@ -1,6 +1,5 @@
 use std::collections::{HashMap};
 use thruster::{Context, Request, Response};
-use tokio::reactor::Handle;
 
 pub struct Ctx {
   pub body: String,
@@ -49,7 +48,7 @@ impl Context for Ctx {
   }
 }
 
-pub fn generate_context(request: &Request, _handle: &Handle) -> Ctx {
+pub fn generate_context(request: &Request) -> Ctx {
   Ctx {
     body: "".to_owned(),
     method: request.method().to_owned(),

--- a/examples/most_basic.rs
+++ b/examples/most_basic.rs
@@ -8,7 +8,6 @@ extern crate tokio;
 
 use std::boxed::Box;
 use futures::future;
-use tokio::reactor::Handle;
 
 use thruster::{App, BasicContext as Ctx, MiddlewareChain, MiddlewareReturnValue, Request};
 
@@ -22,7 +21,7 @@ lazy_static! {
   };
 }
 
-fn generate_context(request: &Request, _handle: &Handle) -> Ctx {
+fn generate_context(request: &Request) -> Ctx {
   Ctx {
     body: "".to_owned(),
     params: request.params().clone()

--- a/src/app.rs
+++ b/src/app.rs
@@ -82,10 +82,10 @@ fn _rehydrate_stars_for_app_with_route<T: 'static + Context + Send>(app: &App<T>
 
 pub struct App<T: 'static + Context + Send> {
   _route_parser: RouteParser<T>,
-  pub context_generator: fn(&Request, &Handle) -> T
+  pub context_generator: fn(&Request) -> T
 }
 
-fn generate_context(request: &Request, _handle: &Handle) -> BasicContext {
+fn generate_context(request: &Request) -> BasicContext {
   BasicContext {
     body: "".to_owned(),
     params: request.params().clone()
@@ -137,7 +137,7 @@ impl<T: Context + Send> App<T> {
     }
   }
 
-  pub fn create(generate_context: fn(&Request, _handle: &Handle) -> T) -> App<T> {
+  pub fn create(generate_context: fn(&Request) -> T) -> App<T> {
     App {
       _route_parser: RouteParser::new(),
       context_generator: generate_context
@@ -232,7 +232,7 @@ impl<T: Context + Send> App<T> {
 
     match matched_route.sub_app {
       Some(sub_app) => {
-        let mut context = (sub_app.context_generator)(&request, handle);
+        let mut context = (sub_app.context_generator)(&request);
 
         let middleware = matched_route.middleware;
         let middleware_chain = MiddlewareChain::new(middleware, handle);
@@ -246,7 +246,7 @@ impl<T: Context + Send> App<T> {
         Box::new(future_response)
       },
       None => {
-        let mut context = (self.context_generator)(&request, handle);
+        let mut context = (self.context_generator)(&request);
 
         let middleware = matched_route.middleware;
         let middleware_chain = MiddlewareChain::new(middleware, handle);
@@ -383,7 +383,7 @@ mod tests {
 
   #[test]
   fn it_should_be_able_to_parse_an_incoming_body() {
-    fn generate_context_with_body(request: &Request, _handle: &tokio::reactor::Handle) -> TypedContext<TestStruct> {
+    fn generate_context_with_body(request: &Request) -> TypedContext<TestStruct> {
       TypedContext::<TestStruct>::new(request)
     }
 


### PR DESCRIPTION
The context generators don't actually need access to the handle since the handle is available more cleanly via the MiddlewareChain struct. This will simplify the generator signature and limit the number of ways to access the current tokio handle.