### PR TITLE
bug: Fix bug in params in subapps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thruster"
-version = "0.3.5"
+version = "0.3.6"
 authors = ["Pete Mertz <peter.s.mertz@gmail.com>"]
 description = "A middleware based http async web server."
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -126,12 +126,3 @@ postgres://postgres@localhost/<Your Project Name>
 ```
 
 This is all configurable and none of it is hidden from the developer. It's like seeing the magic trick and learning how it's done! Check out the docs for [thruster-cli here](https://github.com/trezm/thruster-cli).
-
-### Changelog
-
-#### 0.2.0
-* Breaking Changes
-  * Migrated to use Futures for all middleware callbacks
-* Highlights
-  * Dropped support for tree-based lookup of routes to remove potential branching
-  * Removed many regexes involved in lookup

--- a/src/route_parser.rs
+++ b/src/route_parser.rs
@@ -124,7 +124,11 @@ impl<T: Context + Send> RouteParser<T> {
       }
     };
 
-    self.middleware.insert(accumulator.clone(), new_node);
+    self.add_route_with_node(&accumulator, new_node)
+  }
+
+  pub fn add_route_with_node(&mut self, accumulator: &str, node: RouteNode<T>) {
+    self.middleware.insert(accumulator.to_owned(), node);
   }
 
   pub fn match_route(&self, route: &str) -> MatchedRoute<T> {


### PR DESCRIPTION
**Issue:** When using a subapp, the parameter is not correctly recognized.

**Solution:** This was happening because we were checking for the new route with the old route parser hashmap, i.e. we were checking for `/*` instead of `/test/*`. We shouldn't need to traverse through the map again at all given that we already know what the node should be, so now we bypass the lookup and directly pass the route node in.