### PR TITLE
Make App::start more idiomatic

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ fn main() {
 
   app.get("/plaintext", vec![plaintext]);
 
-  App::start(app, "0.0.0.0", "4321");
+  App::start(app, "0.0.0.0", 4321);
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ fn main() {
 
   app.get("/plaintext", vec![plaintext]);
 
-  App::start(app, "0.0.0.0".to_string(), "4321".to_string());
+  App::start(app, "0.0.0.0", "4321");
 }
 ```
 

--- a/examples/hello_world/main.rs
+++ b/examples/hello_world/main.rs
@@ -63,5 +63,5 @@ fn main() {
 
   app.set404(vec![not_found_404]);
 
-  App::start(app, "0.0.0.0", "4321");
+  App::start(app, "0.0.0.0", 4321);
 }

--- a/examples/hello_world/main.rs
+++ b/examples/hello_world/main.rs
@@ -63,5 +63,5 @@ fn main() {
 
   app.set404(vec![not_found_404]);
 
-  App::start(app, "0.0.0.0".to_string(), "4321".to_string());
+  App::start(app, "0.0.0.0", "4321");
 }

--- a/examples/most_basic.rs
+++ b/examples/most_basic.rs
@@ -31,5 +31,5 @@ fn main() {
 
   app.get("/plaintext", vec![plaintext]);
 
-  App::start(app, "0.0.0.0", "4321");
+  App::start(app, "0.0.0.0", 4321);
 }

--- a/examples/most_basic.rs
+++ b/examples/most_basic.rs
@@ -31,5 +31,5 @@ fn main() {
 
   app.get("/plaintext", vec![plaintext]);
 
-  App::start(app, "0.0.0.0".to_string(), "4321".to_string());
+  App::start(app, "0.0.0.0", "4321");
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -95,7 +95,7 @@ fn generate_context(request: &Request) -> BasicContext {
 }
 
 impl<T: Context + Send> App<T> {
-  pub fn start(app: App<T>, host: &str, port: &str) {
+  pub fn start(app: App<T>, host: &str, port: u16) {
     let addr = format!("{}:{}", host, port).parse().unwrap();
 
     let listener = TcpListener::bind(&addr).unwrap();

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,5 @@
 use std::io;
+use std::net::ToSocketAddrs;
 use std::vec::Vec;
 
 use futures::future;
@@ -96,7 +97,7 @@ fn generate_context(request: &Request) -> BasicContext {
 
 impl<T: Context + Send> App<T> {
   pub fn start(app: App<T>, host: &str, port: u16) {
-    let addr = format!("{}:{}", host, port).parse().unwrap();
+    let addr = (host, port).to_socket_addrs().unwrap().next().unwrap();
 
     let listener = TcpListener::bind(&addr).unwrap();
     let arc_app = Arc::new(app);

--- a/src/app.rs
+++ b/src/app.rs
@@ -95,7 +95,7 @@ fn generate_context(request: &Request) -> BasicContext {
 }
 
 impl<T: Context + Send> App<T> {
-  pub fn start(app: App<T>, host: String, port: String) {
+  pub fn start(app: App<T>, host: &str, port: &str) {
     let addr = format!("{}:{}", host, port).parse().unwrap();
 
     let listener = TcpListener::bind(&addr).unwrap();


### PR DESCRIPTION
This is primarily opinion based, but `to_string()`-s in the example were really grinding my gears. :smile: 

I changed the host to use `&str` instead and the port to be a u16 as I do not see the need to use a string at all in that case. I then also took the opportunity to use `ToSocketAddrs` trait to get rid of string formatting altogether.

This is a breaking change, so a version bump is probably necessary.