### PR TITLE
Remove feature(test) from hello_world example

### DIFF
--- a/examples/hello_world/main.rs
+++ b/examples/hello_world/main.rs
@@ -1,12 +1,9 @@
-#![feature(test)]
-
 extern crate thruster;
 extern crate futures;
 extern crate serde;
 extern crate serde_json;
 extern crate smallvec;
 extern crate tokio;
-extern crate test;
 
 #[macro_use] extern crate serde_derive;
 


### PR DESCRIPTION
There doesn't seem to be any reason that you need `#[feature(test)]` in this example, and it seems having it prevents `cargo test` to run with stable rust.