### PR TITLE
Use feature to control benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,9 @@ documentation = "https://thruster.github.com"
 homepage = "https://thruster.github.com"
 repository = "https://github.com/trezm/thruster"
 
+[features]
+bench = []
+
 [dependencies]
 bytes = "0.4"
 futures = "0.1.20"

--- a/src/app.rs
+++ b/src/app.rs
@@ -252,8 +252,6 @@ impl<T: Context + Send> App<T> {
 
 #[cfg(test)]
 mod tests {
-  // Uncomment to run benchmarks
-  // use test::Bencher;
   use super::*;
   use std::collections::HashMap;
   use bytes::{BytesMut, BufMut};
@@ -296,73 +294,6 @@ mod tests {
       self.body = body;
     }
   }
-
-  // Uncomment to run benchmarks
-  // #[bench]
-  // fn bench_route_match(bench: &mut Bencher) {
-  //   let mut app = App::<BasicContext>::new();
-
-  //   fn test_fn_1(context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
-  //     Box::new(future::ok(BasicContext {
-  //       body: "world".to_owned(),
-  //       params: HashMap::new(),
-  //       query_params: context.query_params
-  //     }))
-  //   };
-
-  //   app.get("/test/hello", vec![test_fn_1]);
-
-  //   bench.iter(|| {
-  //     let mut bytes = BytesMut::with_capacity(47);
-  //     bytes.put(&b"GET /test/hello HTTP/1.1\nHost: localhost:8080\n\n"[..]);
-  //     let request = decode(&mut bytes).unwrap().unwrap();
-  //     let _response = app.resolve(request).wait().unwrap();
-  //   });
-  // }
-
-  // #[bench]
-  // fn bench_route_match_with_param(bench: &mut Bencher) {
-  //   let mut app = App::<BasicContext>::new();
-
-  //   fn test_fn_1(context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
-  //     Box::new(future::ok(BasicContext {
-  //       body: context.params.get("hello").unwrap().to_owned(),
-  //       params: HashMap::new(),
-  //       query_params: context.query_params
-  //     }))
-  //   };
-
-  //   app.get("/test/:hello", vec![test_fn_1]);
-
-  //   bench.iter(|| {
-  //     let mut bytes = BytesMut::with_capacity(48);
-  //     bytes.put(&b"GET /test/world HTTP/1.1\nHost: localhost:8080\n\n"[..]);
-  //     let request = decode(&mut bytes).unwrap().unwrap();
-  //     let _response = app.resolve(request).wait().unwrap();
-  //   });
-  // }
-
-  // #[bench]
-  // fn bench_route_match_with_query_param(bench: &mut Bencher) {
-  //   let mut app = App::<BasicContext>::new();
-
-  //   fn test_fn_1(context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
-  //     Box::new(future::ok(BasicContext {
-  //       body: context.query_params.get("hello").unwrap().to_owned(),
-  //       params: HashMap::new(),
-  //       query_params: context.query_params
-  //     }))
-  //   };
-
-  //   app.get("/test", vec![test_fn_1]);
-
-  //   bench.iter(|| {
-  //     let mut bytes = BytesMut::with_capacity(54);
-  //     bytes.put(&b"GET /test?hello=world HTTP/1.1\nHost: localhost:8080\n\n"[..]);
-  //     let request = decode(&mut bytes).unwrap().unwrap();
-  //     let _response = app.resolve(request).wait().unwrap();
-  //   });
-  // }
 
   #[test]
   fn it_should_execute_all_middlware_with_a_given_request() {
@@ -781,5 +712,85 @@ mod tests {
     let response = app.resolve(request).wait().unwrap();
 
     assert!(response.body() == "not found");
+  }
+}
+
+#[cfg(all(test, feature = "bench"))]
+mod benches {
+  use test::Bencher;
+  use super::*;
+  use std::collections::HashMap;
+  use bytes::{BytesMut, BufMut};
+  use context::BasicContext;
+  use request::decode;
+  use middleware::MiddlewareChain;
+  use futures::{future, Future};
+  use std::io;
+  use std::marker::Send;
+
+  #[bench]
+  fn bench_route_match(bench: &mut Bencher) {
+    let mut app = App::<BasicContext>::new();
+
+    fn test_fn_1(context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+      Box::new(future::ok(BasicContext {
+        body: "world".to_owned(),
+        params: HashMap::new(),
+        query_params: context.query_params
+      }))
+    };
+
+    app.get("/test/hello", vec![test_fn_1]);
+
+    bench.iter(|| {
+      let mut bytes = BytesMut::with_capacity(47);
+      bytes.put(&b"GET /test/hello HTTP/1.1\nHost: localhost:8080\n\n"[..]);
+      let request = decode(&mut bytes).unwrap().unwrap();
+      let _response = app.resolve(request).wait().unwrap();
+    });
+  }
+
+  #[bench]
+  fn bench_route_match_with_param(bench: &mut Bencher) {
+    let mut app = App::<BasicContext>::new();
+
+    fn test_fn_1(context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+      Box::new(future::ok(BasicContext {
+        body: context.params.get("hello").unwrap().to_owned(),
+        params: HashMap::new(),
+        query_params: context.query_params
+      }))
+    };
+
+    app.get("/test/:hello", vec![test_fn_1]);
+
+    bench.iter(|| {
+      let mut bytes = BytesMut::with_capacity(48);
+      bytes.put(&b"GET /test/world HTTP/1.1\nHost: localhost:8080\n\n"[..]);
+      let request = decode(&mut bytes).unwrap().unwrap();
+      let _response = app.resolve(request).wait().unwrap();
+    });
+  }
+
+  #[bench]
+  fn bench_route_match_with_query_param(bench: &mut Bencher) {
+    let mut app = App::<BasicContext>::new();
+
+    fn test_fn_1(context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+      Box::new(future::ok(BasicContext {
+        body: context.query_params.get("hello").unwrap().to_owned(),
+        params: HashMap::new(),
+        query_params: context.query_params
+      }))
+    };
+
+    app.get("/test", vec![test_fn_1]);
+
+    bench.iter(|| {
+      let mut bytes = BytesMut::with_capacity(54);
+      bytes.put(&b"GET /test?hello=world HTTP/1.1\nHost: localhost:8080\n\n"[..]);
+      let request = decode(&mut bytes).unwrap().unwrap();
+      let _response = app.resolve(request).wait().unwrap();
+    });
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
-// Uncomment to run benchmarks
-// #![feature(test)]
+#![cfg_attr(feature = "bench", feature(test))]
 
 extern crate bytes;
 extern crate futures;
@@ -23,9 +22,9 @@ extern crate tokio_io;
 #[allow(unused_imports)]
 extern crate tokio_core;
 
-// Uncomment to run benchmarks
-// #[allow(unused_imports)]
-// extern crate test;
+#[cfg(feature = "bench")]
+#[allow(unused_imports)]
+extern crate test;
 
 mod app;
 mod builtins;


### PR DESCRIPTION
This change allows it to build with stable and bench with nightly without needing to uncomment any code. To benchmark code, you can now just run `cargo +nightly bench --features=bench`.