### PR TITLE
bug: Fix base routes of subtrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,14 @@
 
 [Documentation](https://docs.rs/thruster/0.4.4/thruster/)
 
-thruster is a web framework that aims for developers to be productive and consistent across projects and teams. Its goals are to be:
+Thruster is a web framework that aims for developers to be productive and consistent across projects and teams. Its goals are to be:
 - Opinionated
 - Fast
 - Intuitive
+
+Thruster also
+- Does not use `unsafe`
+- Works in stable rust
 
 ## Opinionated
 

--- a/src/route_tree/mod.rs
+++ b/src/route_tree/mod.rs
@@ -136,9 +136,7 @@ mod tests {
     let mut route_tree = RouteTree::new();
 
     fn test_function(mut context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> MiddlewareReturnValue<BasicContext> {
-      let len = context.params.len();
       context.body = context.params.get("key").unwrap().to_owned();
-      println!("params: {}", len);
 
       Box::new(future::ok(context))
     }


### PR DESCRIPTION
**Issue:** Middleware was not properly getting copied over for the base of a tree into the new subtree at the correct route.

**Solution:** Ensure that when a new subtree is added, the middleware on the root node is _also_ added.