### PR TITLE
bug: Allow pipelined requests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ harness = false
 [dependencies]
 bytes = "0.4"
 futures = "0.1.20"
-http = "0.1.5"
+http = "0.1.7"
 httparse = "1.1.2"
 log = "0.3.6"
 net2 = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thruster"
-version = "0.4.5"
+version = "0.5.0-beta4"
 authors = ["Pete Mertz <peter.s.mertz@gmail.com>"]
 description = "A middleware based http async web server."
 readme = "README.md"

--- a/src/app.rs
+++ b/src/app.rs
@@ -524,8 +524,8 @@ mod tests {
 
     app.post("/test", vec![test_fn_1]);
 
-    let mut bytes = BytesMut::with_capacity(57);
-    bytes.put(&b"POST /test HTTP/1.1\nHost: localhost:8080\n\n{\"key\":\"value\"}"[..]);
+    let mut bytes = BytesMut::with_capacity(76);
+    bytes.put(&b"POST /test HTTP/1.1\nHost: localhost:8080\nContent-Length: 15\n\n{\"key\":\"value\"}"[..]);
 
 
     let request = decode(&mut bytes).unwrap().unwrap();


### PR DESCRIPTION
**Issue:** Requests will not work with pipelines.

**Solution:** Right now requests assume each connection is a single full request. This PR changes that so that `Content-Length` is respected, or the body is assumed to be `0` bytes in the case where `Content-Length` is absent. Note that this doesn _not_ cover chunked data yet.