### PR TITLE
 feat: Improve performance again

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thruster"
-version = "0.5.0-beta5"
+version = "0.5.0-beta7"
 authors = ["Pete Mertz <peter.s.mertz@gmail.com>"]
 description = "A middleware based http async web server."
 readme = "README.md"
@@ -9,13 +9,16 @@ documentation = "https://thruster.github.com"
 homepage = "https://thruster.github.com"
 repository = "https://github.com/trezm/thruster"
 
+[profile.release]
+debug = true
+
 [[bench]]
 name = "app"
 harness = false
 
 [dependencies]
 bytes = "0.4"
-futures = "0.1.20"
+futures = "0.1.23"
 http = "0.1.7"
 httparse = "1.1.2"
 log = "0.3.6"
@@ -26,11 +29,16 @@ serde = "1.0.24"
 serde_json = "1.0.8"
 serde_derive = "1.0.24"
 smallvec = "0.6.2"
+templatify = "0.2.2"
 time = "0.1"
 tokio = "0.1.6"
 tokio-codec = "0.1.0"
 tokio-core = "0.1.17"
 tokio-io = "0.1"
+
+# Other things
+tokio-proto = "0.1"
+tokio-service = "0.1"
 
 [dev-dependencies]
 criterion = "0.2"

--- a/src/app.rs
+++ b/src/app.rs
@@ -10,15 +10,12 @@ use tokio::prelude::*;
 use tokio_codec::Framed;
 
 use context::{BasicContext, Context};
-use http::{Http, HttpProto};
+use http::Http;
 use response::Response;
 use request::Request;
 use route_parser::{MatchedRoute, RouteParser};
 use middleware::{Middleware, MiddlewareChain};
 use std::sync::Arc;
-use tokio_proto::TcpServer;
-use tokio_service::Service;
-use num_cpus;
 
 enum Method {
   DELETE,
@@ -97,37 +94,8 @@ fn generate_context(request: Request) -> BasicContext {
   }
 }
 
-impl<T: 'static + Context + Send> Service for App<T> {
-  type Request = Request;
-  type Response = Response;
-  type Error = io::Error;
-  type Future = Box<Future<Item=Response, Error=io::Error> + Send>;
-
-  fn call(&self, req: Request) -> Self::Future {
-    // Box::new(self.resolve(req))
-    let mut response = Response::new();
-    response.status_code(200, "OK");
-
-    response.header("Content-Type", "text/plain");
-
-    response.body("Hello, world!");
-
-    Box::new(future::ok(response))
-  }
-}
-
 impl<T: Context + Send> App<T> {
   pub fn start(mut app: App<T>, host: &str, port: u16) {
-    // let addr = (host, port).to_socket_addrs().unwrap().next().unwrap();
-    // app._route_parser.optimize();
-
-    // let arc_app = Arc::new(app);
-    // let mut srv = TcpServer::new(HttpProto, addr);
-    // srv.threads(num_cpus::get());
-    // srv.serve(move || {
-    //     Ok(arc_app.clone())
-    // })
-
     let addr = (host, port).to_socket_addrs().unwrap().next().unwrap();
 
     app._route_parser.optimize();
@@ -277,15 +245,6 @@ impl<T: Context + Send> App<T> {
         .and_then(|context| {
           future::ok(context.get_response())
         })
-
-    // let mut response = Response::new();
-    // response.status_code(200, "OK");
-
-    // response.header("Content-Type", "text/plain");
-
-    // response.body("Hello, world!");
-
-    // Box::new(future::ok(response))
   }
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -10,12 +10,15 @@ use tokio::prelude::*;
 use tokio_codec::Framed;
 
 use context::{BasicContext, Context};
-use http::Http;
+use http::{Http, HttpProto};
 use response::Response;
 use request::Request;
 use route_parser::{MatchedRoute, RouteParser};
 use middleware::{Middleware, MiddlewareChain};
 use std::sync::Arc;
+use tokio_proto::TcpServer;
+use tokio_service::Service;
+use num_cpus;
 
 enum Method {
   DELETE,
@@ -39,7 +42,7 @@ fn _add_method_to_route(method: Method, path: &str) -> String {
 
 #[inline]
 fn _add_method_to_route_from_str(method: &str, path: &str) -> String {
-  format!("__{}__{}", method, path)
+  templatify!("__" ; method ; "__" ; path ; "")
 }
 
 ///
@@ -94,8 +97,37 @@ fn generate_context(request: Request) -> BasicContext {
   }
 }
 
+impl<T: 'static + Context + Send> Service for App<T> {
+  type Request = Request;
+  type Response = Response;
+  type Error = io::Error;
+  type Future = Box<Future<Item=Response, Error=io::Error> + Send>;
+
+  fn call(&self, req: Request) -> Self::Future {
+    // Box::new(self.resolve(req))
+    let mut response = Response::new();
+    response.status_code(200, "OK");
+
+    response.header("Content-Type", "text/plain");
+
+    response.body("Hello, world!");
+
+    Box::new(future::ok(response))
+  }
+}
+
 impl<T: Context + Send> App<T> {
   pub fn start(mut app: App<T>, host: &str, port: u16) {
+    // let addr = (host, port).to_socket_addrs().unwrap().next().unwrap();
+    // app._route_parser.optimize();
+
+    // let arc_app = Arc::new(app);
+    // let mut srv = TcpServer::new(HttpProto, addr);
+    // srv.threads(num_cpus::get());
+    // srv.serve(move || {
+    //     Ok(arc_app.clone())
+    // })
+
     let addr = (host, port).to_socket_addrs().unwrap().next().unwrap();
 
     app._route_parser.optimize();
@@ -245,6 +277,15 @@ impl<T: Context + Send> App<T> {
         .and_then(|context| {
           future::ok(context.get_response())
         })
+
+    // let mut response = Response::new();
+    // response.status_code(200, "OK");
+
+    // response.header("Content-Type", "text/plain");
+
+    // response.body("Hello, world!");
+
+    // Box::new(future::ok(response))
   }
 }
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,9 +1,25 @@
 use bytes::BytesMut;
-use tokio_io::codec::{Encoder, Decoder};
+use tokio_io::codec::{Encoder, Decoder, Framed};
+use tokio_io::{AsyncRead, AsyncWrite};
+use tokio_proto::pipeline::ServerProto;
 
 use response::{self, Response};
 use request::{self, Request};
 use std::io;
+
+pub struct HttpProto;
+
+impl<T: AsyncRead + AsyncWrite + 'static> ServerProto<T> for HttpProto {
+    type Request = Request;
+    type Response = Response;
+    type Transport = Framed<T, Http>;
+    type BindTransport = io::Result<Framed<T, Http>>;
+
+    fn bind_transport(&self, io: T) -> io::Result<Framed<T, Http>> {
+        Ok(io.framed(Http))
+    }
+}
+
 
 pub struct Http;
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,25 +1,9 @@
 use bytes::BytesMut;
-use tokio_io::codec::{Encoder, Decoder, Framed};
-use tokio_io::{AsyncRead, AsyncWrite};
-use tokio_proto::pipeline::ServerProto;
+use tokio_io::codec::{Encoder, Decoder};
 
 use response::{self, Response};
 use request::{self, Request};
 use std::io;
-
-pub struct HttpProto;
-
-impl<T: AsyncRead + AsyncWrite + 'static> ServerProto<T> for HttpProto {
-    type Request = Request;
-    type Response = Response;
-    type Transport = Framed<T, Http>;
-    type BindTransport = io::Result<Framed<T, Http>>;
-
-    fn bind_transport(&self, io: T) -> io::Result<Framed<T, Http>> {
-        Ok(io.framed(Http))
-    }
-}
-
 
 pub struct Http;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ extern crate tokio_codec;
 extern crate tokio_io;
 
 #[macro_use] extern crate smallvec;
+#[macro_use] extern crate templatify;
 // For tests
 #[allow(unused_imports)]
 #[macro_use] extern crate serde_derive;
@@ -19,6 +20,9 @@ extern crate tokio_io;
 #[macro_use] extern crate serde_json;
 #[allow(unused_imports)]
 extern crate tokio_core;
+
+extern crate tokio_service;
+extern crate tokio_proto;
 
 mod app;
 mod builtins;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,9 +21,6 @@ extern crate tokio_io;
 #[allow(unused_imports)]
 extern crate tokio_core;
 
-extern crate tokio_service;
-extern crate tokio_proto;
-
 mod app;
 mod builtins;
 mod context;

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,6 +1,5 @@
 use std::{io, str, fmt};
 use std::collections::HashMap;
-use std::iter::Iterator;
 use serde;
 use bytes::BytesMut;
 use serde_json;

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,6 +1,6 @@
 use std::fmt::{self, Write};
 
-use bytes::BytesMut;
+use bytes::{BufMut, BytesMut};
 
 pub struct Response {
     pub response: Vec<u8>,
@@ -28,10 +28,9 @@ impl Response {
     }
 
     pub fn header(&mut self, name: &str, val: &str) -> &mut Response {
-        self.header_raw.extend_from_slice(name.as_bytes());
-        self.header_raw.extend_from_slice(": ".as_bytes());
-        self.header_raw.extend_from_slice(val.as_bytes());
-        self.header_raw.extend_from_slice("\r\n".as_bytes());
+        let header_string = templatify! { "" ; name ; ": " ; val ; "\r\n" };
+        self.header_raw.extend_from_slice(header_string.as_bytes());
+
         self
     }
 
@@ -58,7 +57,7 @@ pub fn encode(msg: Response, buf: &mut BytesMut) {
 
     write!(FastWrite(buf), "\
         HTTP/1.1 {}\r\n\
-        Server: Example\r\n\
+        Server: Thruster\r\n\
         Content-Length: {}\r\n\
         Date: {}\r\n\
     ", msg.status_message, length, now).unwrap();

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,6 +1,6 @@
 use std::fmt::{self, Write};
 
-use bytes::{BufMut, BytesMut};
+use bytes::BytesMut;
 
 pub struct Response {
     pub response: Vec<u8>,
@@ -57,7 +57,7 @@ pub fn encode(msg: Response, buf: &mut BytesMut) {
 
     write!(FastWrite(buf), "\
         HTTP/1.1 {}\r\n\
-        Server: Thruster\r\n\
+        carServer: Thruster\r\n\
         Content-Length: {}\r\n\
         Date: {}\r\n\
     ", msg.status_message, length, now).unwrap();

--- a/src/route_parser.rs
+++ b/src/route_parser.rs
@@ -48,21 +48,6 @@ impl<T: Context + Send> RouteParser<T> {
   pub fn match_route(&self, route: &str) -> MatchedRoute<T> {
     let mut query_params = HashMap::new();
 
-    let mut iter = route.split("?");
-    let route = iter.next().unwrap();
-    match iter.next() {
-      Some(query_string) => {
-        for query_piece in query_string.split("&") {
-          let mut query_iterator = query_piece.split("=");
-          let key = query_iterator.next().unwrap().to_owned();
-          match query_iterator.next() {
-            Some(val) => query_params.insert(key, val.to_owned()),
-            None => query_params.insert(key, "true".to_owned())
-          };
-        }
-      },
-      None => ()
-    };
 
     if let Some(shortcut) = self.shortcuts.get(route) {
       MatchedRoute {
@@ -73,6 +58,22 @@ impl<T: Context + Send> RouteParser<T> {
         sub_app: None
       }
     } else {
+      let mut iter = route.split("?");
+      let route = iter.next().unwrap();
+      match iter.next() {
+        Some(query_string) => {
+          for query_piece in query_string.split("&") {
+            let mut query_iterator = query_piece.split("=");
+            let key = query_iterator.next().unwrap().to_owned();
+            match query_iterator.next() {
+              Some(val) => query_params.insert(key, val.to_owned()),
+              None => query_params.insert(key, "true".to_owned())
+            };
+          }
+        },
+        None => ()
+      };
+
       let matched = self.route_tree.match_route(route);
 
       MatchedRoute {


### PR DESCRIPTION
- Brought back in `templatify` which is more performant than `format!`.
- Removed header iterator which was happening twice
- Moved query string to checking out of shortcuts -- might need to revert this in the future or think of a better option.