### PR TITLE
feat: Improve perf, migrate query params to middleware

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# Contributing
+
+All thoughts and PRs are welcome! Feel free to add any thoughts or discussions as issues via github, or reach out via [gitter](https://gitter.im/thruster-rs/).
+
+## Making Changes
+In order to add or change code in the repository, please open a pull request and reference the issue that the PR resolves in the description.
+
+## We're small!
+This is still a small project, so go crazy :)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thruster"
-version = "0.5.0-beta7"
+version = "0.5.0-beta10"
 authors = ["Pete Mertz <peter.s.mertz@gmail.com>"]
 description = "A middleware based http async web server."
 readme = "README.md"
@@ -35,10 +35,6 @@ tokio = "0.1.6"
 tokio-codec = "0.1.0"
 tokio-core = "0.1.17"
 tokio-io = "0.1"
-
-# Other things
-tokio-proto = "0.1"
-tokio-service = "0.1"
 
 [dev-dependencies]
 criterion = "0.2"

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Based on frameworks like Koa, and Express, thruster aims to be a pleasure to dev
 extern crate thruster;
 extern crate futures;
 
+use std::collections::HashMap;
 use std::boxed::Box;
 use futures::future;
 
@@ -64,8 +65,9 @@ use thruster::{App, BasicContext as Ctx, MiddlewareChain, MiddlewareReturnValue,
 fn generate_context(request: Request) -> Ctx {
   Ctx {
     body: "".to_owned(),
-    params: request.params,
-    query_params: request.query_params
+    params: HashMap::new(),
+    query_params: HashMap::new(),
+    request: request
   }
 }
 

--- a/benches/app.rs
+++ b/benches/app.rs
@@ -11,20 +11,78 @@ use bytes::{BytesMut, BufMut};
 
 use criterion::Criterion;
 use thruster::{decode, App, BasicContext, MiddlewareChain, MiddlewareReturnValue};
+use thruster::builtins::query_params::query_params;
+
+fn bench_no_check(c: &mut Criterion) {
+  c.bench_function("No check", |bench| {
+    bench.iter(|| {
+      let v = vec!["a"];
+
+      let _ = v.get(0).unwrap();
+    });
+  });
+}
+fn bench_expect(c: &mut Criterion) {
+  c.bench_function("Expect", |bench| {
+    bench.iter(|| {
+      let v = vec!["a"];
+
+      let _ = v.get(0).expect("Yikes");
+    });
+  });
+}
+fn bench_assert(c: &mut Criterion) {
+  c.bench_function("Assert", |bench| {
+    bench.iter(|| {
+      let v = vec!["a"];
+
+      let a = v.get(0);
+      assert!(a.is_some());
+      let _ = a.unwrap();
+    });
+  });
+}
+fn bench_remove(c: &mut Criterion) {
+  c.bench_function("Remove", |bench| {
+    bench.iter(|| {
+      let mut v = vec!["a"];
+
+      let a = v.remove(0);
+    });
+  });
+}
 
 fn bench_route_match(c: &mut Criterion) {
   c.bench_function("Route match", |bench| {
     let mut app = App::<BasicContext>::new();
 
-    fn test_fn_1(context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> MiddlewareReturnValue<BasicContext> {
-      Box::new(future::ok(BasicContext {
-        body: "world".to_owned(),
-        params: HashMap::new(),
-        query_params: context.query_params
-      }))
+    fn test_fn_1(mut context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> MiddlewareReturnValue<BasicContext> {
+      context.body = "world".to_owned();
+      Box::new(future::ok(context))
     };
 
     app.get("/test/hello", vec![test_fn_1]);
+
+    bench.iter(|| {
+      let mut bytes = BytesMut::with_capacity(47);
+      bytes.put(&b"GET /test/hello HTTP/1.1\nHost: localhost:8080\n\n"[..]);
+      let request = decode(&mut bytes).unwrap().unwrap();
+      let _response = app.resolve(request).wait().unwrap();
+    });
+  });
+}
+
+fn optimized_bench_route_match(c: &mut Criterion) {
+  c.bench_function("Optimized route match", |bench| {
+    let mut app = App::<BasicContext>::new();
+
+    fn test_fn_1(mut context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> MiddlewareReturnValue<BasicContext> {
+      context.body = "world".to_owned();
+      Box::new(future::ok(context))
+    };
+
+    app.get("/test/hello", vec![test_fn_1]);
+    app._route_parser.optimize();
 
     bench.iter(|| {
       let mut bytes = BytesMut::with_capacity(47);
@@ -39,12 +97,9 @@ fn bench_route_match_with_param(c: &mut Criterion) {
   c.bench_function("Route match with route params", |bench| {
     let mut app = App::<BasicContext>::new();
 
-    fn test_fn_1(context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> MiddlewareReturnValue<BasicContext> {
-      Box::new(future::ok(BasicContext {
-        body: context.params.get("hello").unwrap().to_owned(),
-        params: HashMap::new(),
-        query_params: context.query_params
-      }))
+    fn test_fn_1(mut context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> MiddlewareReturnValue<BasicContext> {
+      context.body = context.params.get("hello").unwrap().to_owned();
+      Box::new(future::ok(context))
     };
 
     app.get("/test/:hello", vec![test_fn_1]);
@@ -62,14 +117,12 @@ fn bench_route_match_with_query_param(c: &mut Criterion) {
   c.bench_function("Route match with query params", |bench| {
     let mut app = App::<BasicContext>::new();
 
-    fn test_fn_1(context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> MiddlewareReturnValue<BasicContext> {
-      Box::new(future::ok(BasicContext {
-        body: context.query_params.get("hello").unwrap().to_owned(),
-        params: HashMap::new(),
-        query_params: context.query_params
-      }))
+    fn test_fn_1(mut context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> MiddlewareReturnValue<BasicContext> {
+      context.body = context.query_params.get("hello").unwrap().to_owned();
+      Box::new(future::ok(context))
     };
 
+    app.use_middleware("/", query_params);
     app.get("/test", vec![test_fn_1]);
 
     bench.iter(|| {
@@ -81,6 +134,14 @@ fn bench_route_match_with_query_param(c: &mut Criterion) {
   });
 }
 
-criterion_group!(benches, bench_route_match, bench_route_match_with_param, bench_route_match_with_query_param);
+criterion_group!(benches,
+  // bench_no_check,
+  // bench_assert,
+  // bench_expect,
+  // bench_remove,
+  optimized_bench_route_match,
+  bench_route_match,
+  bench_route_match_with_param,
+  bench_route_match_with_query_param);
 criterion_main!(benches);
 

--- a/examples/hello_world/context.rs
+++ b/examples/hello_world/context.rs
@@ -8,9 +8,9 @@ pub struct Ctx {
   pub path: String,
   pub request_body: String,
   pub params: HashMap<String, String>,
-  pub query_params: HashMap<String, String>,
   pub headers: SmallVec<[(String, String); 8]>,
-  pub status_code: u32
+  pub status_code: u32,
+  response: Response
 }
 
 impl Ctx {
@@ -20,32 +20,25 @@ impl Ctx {
       method: context.method,
       path: context.path,
       params: context.params,
-      query_params: context.query_params,
       request_body: context.request_body,
       headers: SmallVec::new(),
-      status_code: 200
+      status_code: 200,
+      response: Response::new()
     }
   }
 
-  pub fn set_header(&mut self, key: String, val: String) {
-    self.headers.push((key, val));
+  pub fn set_header(&mut self, key: &str, val: &str) {
+    self.response.header(key, val);
   }
 }
 
 impl Context for Ctx {
-  fn get_response(&self) -> Response {
-    let mut response = Response::new();
-    response.status_code(200, "OK");
+  fn get_response(mut self) -> Response {
+    self.response.status_code(200, "OK");
 
-    for header_pair in &self.headers {
-      let key: &str = &header_pair.0;
-      let val: &str = &header_pair.1;
-      response.header(key, val);
-    }
+    self.response.body(&self.body);
 
-    response.body(&self.body);
-
-    response
+    self.response
   }
 
   fn set_body(&mut self, body: String) {
@@ -63,9 +56,9 @@ pub fn generate_context(request: Request) -> Ctx {
     method: method,
     path: path,
     params: request.params,
-    query_params: request.query_params,
     request_body: request_body,
     headers: SmallVec::new(),
-    status_code: 200
+    status_code: 200,
+    response: Response::new()
   }
 }

--- a/examples/hello_world/main.rs
+++ b/examples/hello_world/main.rs
@@ -20,7 +20,7 @@ fn not_found_404(context: Ctx, _chain: &MiddlewareChain<Ctx>) -> MiddlewareRetur
   context.body = "<html>
   ( ͡° ͜ʖ ͡°) What're you looking for here?
 </html>".to_owned();
-  context.set_header("Content-Type".to_owned(), "text/html".to_owned());
+  context.set_header("Content-Type", "text/html");
   context.status_code = 404;
 
   Box::new(future::ok(context))
@@ -38,8 +38,7 @@ fn json(mut context: Ctx, _chain: &MiddlewareChain<Ctx>) -> MiddlewareReturnValu
   let val = serde_json::to_string(&json).unwrap();
 
   context.body = val;
-  context.set_header("Server".to_owned(), "thruster".to_owned());
-  context.set_header("Content-Type".to_owned(), "application/json".to_owned());
+  context.set_header("Content-Type", "application/json");
 
   Box::new(future::ok(context))
 }
@@ -48,8 +47,7 @@ fn plaintext(mut context: Ctx, _chain: &MiddlewareChain<Ctx>) -> MiddlewareRetur
   let val = "Hello, World!".to_owned();
 
   context.body = val;
-  context.set_header("Server".to_owned(), "thruster".to_owned());
-  context.set_header("Content-Type".to_owned(), "text/plain".to_owned());
+  context.set_header("Content-Type", "text/plain");
 
   Box::new(future::ok(context))
 }
@@ -61,6 +59,7 @@ fn main() {
 
   app.get("/json", vec![json]);
   app.get("/plaintext", vec![plaintext]);
+  app.post("/post-plaintext", vec![plaintext]);
 
   app.set404(vec![not_found_404]);
 

--- a/examples/most_basic.rs
+++ b/examples/most_basic.rs
@@ -1,6 +1,7 @@
 extern crate thruster;
 extern crate futures;
 
+use std::collections::HashMap;
 use std::boxed::Box;
 use futures::future;
 
@@ -9,8 +10,9 @@ use thruster::{App, BasicContext as Ctx, MiddlewareChain, MiddlewareReturnValue,
 fn generate_context(request: Request) -> Ctx {
   Ctx {
     body: "".to_owned(),
-    params: request.params,
-    query_params: request.query_params
+    params: HashMap::new(),
+    query_params: HashMap::new(),
+    request: request
   }
 }
 

--- a/src/builtins/basic_context.rs
+++ b/src/builtins/basic_context.rs
@@ -1,0 +1,60 @@
+use std::collections::HashMap;
+
+use context::Context;
+use response::Response;
+use request::Request;
+use builtins::retains_request::RetainsRequest;
+use builtins::query_params::HasQueryParams;
+
+pub fn generate_context(request: Request) -> BasicContext {
+  BasicContext {
+    body: "".to_owned(),
+    params: request.params().clone(),
+    request: request,
+    query_params: HashMap::new()
+  }
+}
+
+pub struct BasicContext {
+  pub body: String,
+  pub params: HashMap<String, String>,
+  pub query_params: HashMap<String, String>,
+  pub request: Request
+}
+
+impl BasicContext {
+  pub fn new() -> BasicContext {
+    BasicContext {
+      body: "".to_owned(),
+      params: HashMap::new(),
+      query_params: HashMap::new(),
+      request: Request::new()
+    }
+  }
+}
+
+impl Context for BasicContext {
+  fn get_response(self) -> Response {
+    let mut response = Response::new();
+
+    response.body(&self.body);
+
+    response
+  }
+
+  fn set_body(&mut self, body: String) {
+    self.body = body;
+  }
+}
+
+impl RetainsRequest for BasicContext {
+  fn get_request<'a>(&'a self) -> &'a Request {
+    &self.request
+  }
+}
+
+impl HasQueryParams for BasicContext {
+  fn set_query_params(&mut self, query_params: HashMap<String, String>) {
+    self.query_params = query_params;
+  }
+}

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -1,1 +1,4 @@
 pub mod send;
+pub mod query_params;
+pub mod retains_request;
+pub mod basic_context;

--- a/src/builtins/query_params.rs
+++ b/src/builtins/query_params.rs
@@ -1,0 +1,38 @@
+use std::collections::HashMap;
+
+use context::Context;
+use middleware::{MiddlewareChain, MiddlewareReturnValue};
+use builtins::retains_request::RetainsRequest;
+
+pub trait HasQueryParams {
+  fn set_query_params(&mut self, query_params: HashMap<String, String>);
+}
+
+pub fn query_params<T: 'static + Context + HasQueryParams + RetainsRequest + Send>(mut context: T, chain: &MiddlewareChain<T>) -> MiddlewareReturnValue<T> {
+  let mut query_param_hash = HashMap::new();
+
+  {
+    let route: &str = &context.get_request().path();
+
+    let mut iter = route.split("?");
+    // Get rid of first bit (the non-query string part)
+    let _ = iter.next().unwrap();
+    match iter.next() {
+      Some(query_string) => {
+        for query_piece in query_string.split("&") {
+          let mut query_iterator = query_piece.split("=");
+          let key = query_iterator.next().unwrap().to_owned();
+          match query_iterator.next() {
+            Some(val) => query_param_hash.insert(key, val.to_owned()),
+            None => query_param_hash.insert(key, "true".to_owned())
+          };
+        }
+      },
+      None => ()
+    };
+  }
+
+  context.set_query_params(query_param_hash);
+
+  chain.next(context)
+}

--- a/src/builtins/retains_request.rs
+++ b/src/builtins/retains_request.rs
@@ -1,0 +1,5 @@
+use request::Request;
+
+pub trait RetainsRequest {
+  fn get_request<'a>(&'a self) -> &'a Request;
+}

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use response::Response;
 
 /// A `Context` is what will be passed between functions in the middleware for
@@ -6,36 +5,6 @@ use response::Response;
 /// incomming request, it's important to keep this struct lean and quick, as
 /// well as the `context_generator` associated with it.
 pub trait Context {
-  fn get_response(&self) -> Response;
+  fn get_response(self) -> Response;
   fn set_body(&mut self, String);
-}
-
-pub struct BasicContext {
-  pub body: String,
-  pub params: HashMap<String, String>,
-  pub query_params: HashMap<String, String>
-}
-
-impl BasicContext {
-  pub fn new() -> BasicContext {
-    BasicContext {
-      body: "".to_owned(),
-      params: HashMap::new(),
-      query_params: HashMap::new()
-    }
-  }
-}
-
-impl Context for BasicContext {
-  fn get_response(&self) -> Response {
-    let mut response = Response::new();
-
-    response.body(&self.body);
-
-    response
-  }
-
-  fn set_body(&mut self, body: String) {
-    self.body = body;
-  }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ extern crate tokio_io;
 extern crate tokio_core;
 
 mod app;
-mod builtins;
+pub mod builtins;
 mod context;
 mod date;
 mod http;
@@ -33,8 +33,8 @@ mod route_parser;
 mod route_tree;
 
 pub use app::App;
-pub use builtins::send::file;
-pub use context::{BasicContext, Context};
+pub use context::Context;
+pub use builtins::basic_context::BasicContext;
 pub use middleware::{Middleware, MiddlewareChain, MiddlewareReturnValue};
 pub use response::{encode, Response};
 pub use request::{decode, Request};

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -2,7 +2,7 @@ use context::{Context};
 use smallvec::SmallVec;
 use std::cell::Cell;
 use std::boxed::Box;
-use futures::{future, Future};
+use futures::Future;
 use std::io;
 
 /// `MiddlewareReturnValue`s are the values that Thruster expects middleware to return. It's
@@ -20,28 +20,23 @@ pub type Middleware<T> = fn(T, chain: &MiddlewareChain<T>) -> MiddlewareReturnVa
 /// proceed with work accordingly.
 pub struct MiddlewareChain<'a, T: 'a + Context> {
   _chain_index: Cell<usize>,
-  pub middleware: &'a SmallVec<[Middleware<T>; 8]>,
-  pub not_found: &'a SmallVec<[Middleware<T>; 8]>
+  pub middleware: &'a SmallVec<[Middleware<T>; 8]>
 }
 
 impl<'a, T: 'static + Context + Send> MiddlewareChain<'a, T> {
   /// Create a new `MiddlewareChain` with a vector of middleware to be executed.
-  pub fn new(middleware: &'a SmallVec<[Middleware<T>; 8]>, not_found: &'a SmallVec<[Middleware<T>; 8]>) -> MiddlewareChain<'a, T> {
+  pub fn new(middleware: &'a SmallVec<[Middleware<T>; 8]>) -> MiddlewareChain<'a, T> {
     MiddlewareChain {
       middleware: middleware,
-      _chain_index: Cell::new(0),
-      not_found: not_found
+      _chain_index: Cell::new(0)
     }
   }
 
   pub fn next(&self, context: T) -> MiddlewareReturnValue<T> {
-    let next_middleware = self.middleware.get(self._chain_index.get())
-      .or_else(|| self.not_found.get(self._chain_index.get() - self.middleware.len()));
+    let next_middleware = self.middleware.get(self._chain_index.get());
     self._chain_index.set(self._chain_index.get() + 1);
 
-    match next_middleware {
-      Some(middleware) => middleware(context, self),
-      None => Box::new(future::ok(context))
-    }
+    assert!(next_middleware.is_some());
+    next_middleware.unwrap()(context, self)
   }
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -16,13 +16,24 @@ pub struct Request {
     // TODO: use a small vec to avoid this unconditional allocation
     pub headers: SmallVec<[(Slice, Slice); 8]>,
     data: BytesMut,
-    pub params: HashMap<String, String>,
-    pub query_params: HashMap<String, String>
+    pub params: HashMap<String, String>
 }
 
 type Slice = (usize, usize);
 
 impl Request {
+    pub fn new() -> Self {
+      Request  {
+        body: (0,0),
+        method: (0,0),
+        path: (0,0),
+        version: 0,
+        headers: SmallVec::new(),
+        data: BytesMut::new(),
+        params: HashMap::new(),
+      }
+    }
+
     pub fn raw_body(&self) -> &str {
         str::from_utf8(self.slice(&self.body)).unwrap()
     }
@@ -66,16 +77,8 @@ impl Request {
         &self.params
     }
 
-    pub fn query_params(&self) -> &HashMap<String, String> {
-        &self.query_params
-    }
-
     pub fn set_params(&mut self, params: HashMap<String, String>) {
         self.params = params;
-    }
-
-    pub fn set_query_params(&mut self, query_params: HashMap<String, String>) {
-        self.query_params = query_params;
     }
 }
 
@@ -136,7 +139,6 @@ pub fn decode(buf: &mut BytesMut) -> io::Result<Option<Request>> {
         headers: headers,
         data: buf.split_to(amt + body_len),
         body: (amt, amt + body_len),
-        params: HashMap::new(),
-        query_params: HashMap::new()
+        params: HashMap::new()
     }.into())
 }

--- a/src/response.rs
+++ b/src/response.rs
@@ -57,7 +57,7 @@ pub fn encode(msg: Response, buf: &mut BytesMut) {
 
     write!(FastWrite(buf), "\
         HTTP/1.1 {}\r\n\
-        carServer: Thruster\r\n\
+        Server: Thruster\r\n\
         Content-Length: {}\r\n\
         Date: {}\r\n\
     ", msg.status_message, length, now).unwrap();

--- a/src/route_tree/mod.rs
+++ b/src/route_tree/mod.rs
@@ -104,7 +104,7 @@ mod tests {
   use super::RouteTree;
   use super::Method;
   use std::collections::HashMap;
-  use context::BasicContext;
+  use builtins::basic_context::BasicContext;
   use middleware::{Middleware, MiddlewareChain, MiddlewareReturnValue};
   use futures::{future, Future};
   use std::boxed::Box;
@@ -123,7 +123,7 @@ mod tests {
     route_tree.add_route_with_method(Method::GET, "/a/b", smallvec![test_function as Middleware<BasicContext>]);
     let middleware = route_tree.match_route_with_params("__GET__/a/b", HashMap::new());
 
-    let result = middleware.0[0](BasicContext::new(), &MiddlewareChain::new(&smallvec![], &smallvec![]))
+    let result = middleware.0[0](BasicContext::new(), &MiddlewareChain::new(&smallvec![]))
       .wait()
       .unwrap();
 
@@ -147,7 +147,7 @@ mod tests {
     let mut context = BasicContext::new();
     context.params = middleware.1;
 
-    let result = middleware.0[0](context, &MiddlewareChain::new(&smallvec![], &smallvec![]))
+    let result = middleware.0[0](context, &MiddlewareChain::new(&smallvec![]))
       .wait()
       .unwrap();
 
@@ -176,7 +176,7 @@ mod tests {
 
     let middleware = route_tree1.match_route_with_params("__GET__/b/c", HashMap::new());
 
-    let result = middleware.0[0](BasicContext::new(), &MiddlewareChain::new(&smallvec![], &smallvec![]))
+    let result = middleware.0[0](BasicContext::new(), &MiddlewareChain::new(&smallvec![]))
       .wait()
       .unwrap();
 


### PR DESCRIPTION
This PR:
- Allows the option to optimize for small requests via `start_small_load_optimized`
- Moves query params into a middleware so not all routes are slowed by processing query parameters by default
- Removes safety check from middleware. If, for example, a terminal piece of middleware calls next, you'll see an exception. This might be added back in in the future.
- Adds a CONTRIBUTING.md file (#51)