### PR TITLE
bug: Fix nested routes with wildcards

### DIFF
--- a/examples/hello_world/context.rs
+++ b/examples/hello_world/context.rs
@@ -49,7 +49,7 @@ impl Context for Ctx {
 pub fn generate_context(request: Request) -> Ctx {
   let method = request.method().to_owned();
   let path = request.path().to_owned();
-  let request_body = request.raw_body().to_owned();
+  let request_body = request.body().to_owned();
 
   Ctx {
     body: "".to_owned(),

--- a/examples/hello_world/main.rs
+++ b/examples/hello_world/main.rs
@@ -61,7 +61,10 @@ fn main() {
   app.get("/plaintext", vec![plaintext]);
   app.post("/post-plaintext", vec![plaintext]);
 
-  app.set404(vec![not_found_404]);
+  app.get("/*", vec![not_found_404]);
+
+  app.get("/test/a/b", vec![plaintext]);
+  app.get("/test/a/c", vec![plaintext]);
 
   App::start(app, "0.0.0.0", 4321);
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -34,7 +34,11 @@ impl Request {
       }
     }
 
-    pub fn raw_body(&self) -> &str {
+    pub fn raw_body(&self) -> &[u8] {
+        self.slice(&self.body)
+    }
+
+    pub fn body(&self) -> &str {
         str::from_utf8(self.slice(&self.body)).unwrap()
     }
 

--- a/src/route_tree/mod.rs
+++ b/src/route_tree/mod.rs
@@ -91,11 +91,15 @@ impl<T: Context + Send> RouteTree<T> {
   }
 
   pub fn match_route(&self, route: &str) -> (&SmallVec<[Middleware<T>; 8]>, HashMap<String, String>) {
-    self.root_node.match_route(route.split("/"))
+    let results = self.root_node.match_route(route.split("/"));
+
+    (results.0, results.1)
   }
 
   pub fn match_route_with_params(&self, route: &str, params: HashMap<String, String>) -> (&SmallVec<[Middleware<T>; 8]>, HashMap<String, String>) {
-    self.root_node.match_route_with_params(route.split("/"), params)
+    let results = self.root_node.match_route_with_params(route.split("/"), params);
+
+    (results.0, results.1)
   }
 }
 


### PR DESCRIPTION
**Issue:** Nested routes if they miss do not default to a parent wildcard (`*`) route.

**Solution:** I re-added the concept of a "terminal node" into the tree. If a route does not match a terminal node, it will trace back up its stack until it finds a terminal node and use its middleware. If no terminal node is found, then no middleware is passed and an assertion will fail.

Resolves [#53]