### PR TITLE
bug: fix paramaterized nodes treated terminally

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -955,6 +955,35 @@ mod tests {
     assert!(String::from_utf8(response.response).unwrap() == "not found");
   }
 
+#[test]
+  fn it_should_be_able_to_correctly_handle_deep_not_found_routes_after_root_route() {
+    let mut app1 = App::<BasicContext>::new();
+    let mut app2 = App::<BasicContext>::new();
+    let mut app3 = App::<BasicContext>::new();
+
+    fn test_fn_1(mut context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+      context.body = "1".to_owned();
+      Box::new(future::ok(context))
+    };
+
+    fn test_404(mut context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+      context.body = "not found".to_owned();
+      Box::new(future::ok(context))
+    };
+
+    app1.get("/", vec![test_fn_1]);
+    app2.get("*", vec![test_404]);
+    app3.use_sub_app("/", app2);
+    app3.use_sub_app("/a", app1);
+
+    let mut bytes = BytesMut::with_capacity(45);
+    bytes.put(&b"GET /a/1/d HTTP/1.1\nHost: localhost:8080\n\n"[..]);
+
+    let request = decode(&mut bytes).unwrap().unwrap();
+    let response = app3.resolve(request).wait().unwrap();
+
+    assert!(String::from_utf8(response.response).unwrap() == "not found");
+  }
 
   #[test]
   fn it_should_handle_routes_without_leading_slash() {

--- a/src/route_tree/node.rs
+++ b/src/route_tree/node.rs
@@ -81,7 +81,7 @@ impl<T: Context + Send> Node<T> {
           ':' => {
             if !self.is_wildcard {
               let mut wildcard = Node::new_wildcard(Some(piece[1..].to_owned()));
-              wildcard.is_terminal_node = true;
+              wildcard.is_terminal_node = false;
 
               wildcard.add_route(&split_iterator.collect::<SmallVec<[&str; 8]>>().join("/"), middleware);
 
@@ -207,7 +207,7 @@ impl<T: Context + Send> Node<T> {
                 if results.2 {
                   results
                 } else {
-                  (&self.middleware, results.1, self.is_terminal_node)
+                  (&self.middleware, results.1, wildcard_node.is_terminal_node)
                 }
               }
             }
@@ -233,7 +233,10 @@ impl<T: Context + Send> Node<T> {
   /// ```
   pub fn to_string(&self, indent: &str) -> String {
     let mut in_progress = "".to_owned();
-    let value = self.param_key.clone().unwrap_or(self.value.to_owned());
+    let value = match self.param_key.clone() {
+      Some(key) => format!(":{}", key),
+      None => self.value.to_owned()
+    };
 
     in_progress = format!("{}\n{}{}: {}, {}",
       in_progress,


### PR DESCRIPTION
**Issue:** Paramaterized nodes, e.g. `:id`, are always being made to be terminal.

**Solution:** Do not do so, as the recursion takes care of that if the next piece is 0 length.