### PR TITLE
feat: Add diesel example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,9 @@ tokio-io = "0.1"
 
 [dev-dependencies]
 criterion = "0.2"
+diesel = { version = "1.3", features = ["postgres", "r2d2"] }
+dotenv = "0.13.0"
+lazy_static = "1.1.0"
 rustc-serialize = "0.3"
 num_cpus = "1.0"
 env_logger = { version = "0.3.4", default-features = false }

--- a/examples/diesel/.env
+++ b/examples/diesel/.env
@@ -1,0 +1,1 @@
+DATABASE_URL=postgres://username:password@localhost/diesel

--- a/examples/diesel/content_model.rs
+++ b/examples/diesel/content_model.rs
@@ -1,0 +1,5 @@
+#[derive(Queryable)]
+pub struct Content {
+    pub id: i32,
+    pub val: String
+}

--- a/examples/diesel/context.rs
+++ b/examples/diesel/context.rs
@@ -1,0 +1,52 @@
+use std::collections::{HashMap};
+use smallvec::SmallVec;
+
+use thruster::{Context, Response, Request};
+
+pub struct Ctx {
+  pub body: String,
+  pub method: String,
+  pub path: String,
+  pub request_body: String,
+  pub params: HashMap<String, String>,
+  pub headers: SmallVec<[(String, String); 8]>,
+  pub status_code: u32,
+  pub response: Response
+}
+
+impl Ctx {
+  pub fn set_header(&mut self, key: &str, val: &str) {
+    self.response.header(key, val);
+  }
+}
+
+impl Context for Ctx {
+  fn get_response(mut self) -> Response {
+    self.response.status_code(200, "OK");
+
+    self.response.body(&self.body);
+
+    self.response
+  }
+
+  fn set_body(&mut self, body: String) {
+    self.body = body;
+  }
+}
+
+pub fn generate_context(request: Request) -> Ctx {
+  let method = request.method().to_owned();
+  let path = request.path().to_owned();
+  let request_body = request.body().to_owned();
+
+  Ctx {
+    body: "".to_owned(),
+    method: method,
+    path: path,
+    params: request.params,
+    request_body: request_body,
+    headers: SmallVec::new(),
+    status_code: 200,
+    response: Response::new()
+  }
+}

--- a/examples/diesel/main.rs
+++ b/examples/diesel/main.rs
@@ -1,0 +1,72 @@
+extern crate thruster;
+extern crate futures;
+extern crate serde;
+extern crate serde_json;
+extern crate smallvec;
+extern crate tokio;
+extern crate dotenv;
+
+#[macro_use] extern crate diesel;
+#[macro_use] extern crate lazy_static;
+
+mod context;
+mod schema;
+mod content_model;
+
+use futures::future;
+
+use thruster::{App, MiddlewareChain, MiddlewareReturnValue};
+use context::{Ctx, generate_context};
+use diesel::prelude::*;
+use diesel::pg::PgConnection;
+use diesel::r2d2::{ConnectionManager, Pool};
+use schema::content::dsl::*;
+use dotenv::dotenv;
+use std::env;
+
+lazy_static! {
+    static ref psql: Pool<ConnectionManager<PgConnection>> = {
+      dotenv().ok();
+
+      let database_url = env::var("DATABASE_URL")
+        .expect("DATABASE_URL must be set");
+
+      let manager = ConnectionManager::<PgConnection>::new(database_url);
+      Pool::new(manager).expect("Error creating db pool")
+    };
+}
+
+fn fetch_value(mut context: Ctx, _chain: &MiddlewareChain<Ctx>) -> MiddlewareReturnValue<Ctx> {
+  let conn = psql.get().unwrap();
+
+  let results = content
+    .limit(1)
+    .load::<content_model::Content>(&conn)
+    .unwrap();
+
+  let result = results.get(0).unwrap();
+  context.body = result.val.clone();
+
+  Box::new(future::ok(context))
+}
+
+fn not_found_404(mut context: Ctx, _chain: &MiddlewareChain<Ctx>) -> MiddlewareReturnValue<Ctx> {
+  context.body = "<html>
+  ( ͡° ͜ʖ ͡°) What're you looking for here?
+</html>".to_owned();
+  context.set_header("Content-Type", "text/html");
+  context.status_code = 404;
+
+  Box::new(future::ok(context))
+}
+
+fn main() {
+  println!("Starting server...");
+
+  let mut app = App::create(generate_context);
+
+  app.get("/plaintext", vec![fetch_value]);
+  app.get("/*", vec![not_found_404]);
+
+  App::start(app, "0.0.0.0", 4321);
+}

--- a/examples/diesel/migrations/00000000000000_diesel_initial_setup/down.sql
+++ b/examples/diesel/migrations/00000000000000_diesel_initial_setup/down.sql
@@ -1,0 +1,2 @@
+DROP FUNCTION IF EXISTS diesel_manage_updated_at(_tbl regclass);
+DROP FUNCTION IF EXISTS diesel_set_updated_at();

--- a/examples/diesel/migrations/00000000000000_diesel_initial_setup/up.sql
+++ b/examples/diesel/migrations/00000000000000_diesel_initial_setup/up.sql
@@ -1,0 +1,36 @@
+-- This file was automatically created by Diesel to setup helper functions
+-- and other internal bookkeeping. This file is safe to edit, any future
+-- changes will be added to existing projects as new migrations.
+
+
+
+
+-- Sets up a trigger for the given table to automatically set a column called
+-- `updated_at` whenever the row is modified (unless `updated_at` was included
+-- in the modified columns)
+--
+-- # Example
+--
+-- ```sql
+-- CREATE TABLE users (id SERIAL PRIMARY KEY, updated_at TIMESTAMP NOT NULL DEFAULT NOW());
+--
+-- SELECT diesel_manage_updated_at('users');
+-- ```
+CREATE OR REPLACE FUNCTION diesel_manage_updated_at(_tbl regclass) RETURNS VOID AS $$
+BEGIN
+    EXECUTE format('CREATE TRIGGER set_updated_at BEFORE UPDATE ON %s
+                    FOR EACH ROW EXECUTE PROCEDURE diesel_set_updated_at()', _tbl);
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION diesel_set_updated_at() RETURNS trigger AS $$
+BEGIN
+    IF (
+        NEW IS DISTINCT FROM OLD AND
+        NEW.updated_at IS NOT DISTINCT FROM OLD.updated_at
+    ) THEN
+        NEW.updated_at := current_timestamp;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/examples/diesel/migrations/2018-09-07-121333_create_content/down.sql
+++ b/examples/diesel/migrations/2018-09-07-121333_create_content/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+DROP TABLE content

--- a/examples/diesel/migrations/2018-09-07-121333_create_content/up.sql
+++ b/examples/diesel/migrations/2018-09-07-121333_create_content/up.sql
@@ -1,0 +1,5 @@
+-- Your SQL goes here
+CREATE TABLE content (
+  id SERIAL PRIMARY KEY,
+  val TEXT NOT NULL
+)

--- a/examples/diesel/migrations/2018-09-07-130042_add_content/down.sql
+++ b/examples/diesel/migrations/2018-09-07-130042_add_content/down.sql
@@ -1,0 +1,1 @@
+-- This file should undo anything in `up.sql`

--- a/examples/diesel/migrations/2018-09-07-130042_add_content/up.sql
+++ b/examples/diesel/migrations/2018-09-07-130042_add_content/up.sql
@@ -1,0 +1,3 @@
+-- Your SQL goes here
+INSERT INTO content(val)
+VALUES ('Hello, world!');

--- a/examples/diesel/schema.rs
+++ b/examples/diesel/schema.rs
@@ -1,0 +1,6 @@
+table! {
+    content (id) {
+        id -> Int4,
+        val -> Text,
+    }
+}

--- a/examples/hello_world/main.rs
+++ b/examples/hello_world/main.rs
@@ -63,8 +63,5 @@ fn main() {
 
   app.get("/*", vec![not_found_404]);
 
-  app.get("/test/a/b", vec![plaintext]);
-  app.get("/test/a/c", vec![plaintext]);
-
   App::start(app, "0.0.0.0", 4321);
 }


### PR DESCRIPTION
Add a diesel example using `lazy_static` and `r2d2` as a connection pool. This is similar to how the standard practice in Node is with singleton modules.