### PR TITLE
feat: Add headers and status to test harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,5 +129,5 @@ app.get("/plaintext", vec![plaintext]);
 
 let result = testing::get(app, "/plaintext");
 
-assert!(result == "Hello, World!");
+assert!(result.body == "Hello, World!");
 ```

--- a/examples/run_test/main.rs
+++ b/examples/run_test/main.rs
@@ -20,5 +20,5 @@ fn main() {
 
   let result = testing::get(app, "/plaintext");
 
-  assert!(result == "Hello, World!");
+  assert!(result.body == "Hello, World!");
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -335,7 +335,7 @@ mod tests {
   use super::*;
   use testing;
   use context::Context;
-  use request::{decode, Request};
+  use request::Request;
   use middleware::{MiddlewareChain, MiddlewareReturnValue};
   use response::Response;
   use serde;
@@ -391,7 +391,7 @@ mod tests {
 
     let response = testing::get(app, "/test");
 
-    assert!(response == "1");
+    assert!(response.body == "1");
   }
 
 
@@ -409,7 +409,7 @@ mod tests {
 
     let response = testing::get(app, "/test?hello=world");
 
-    assert!(response == "world");
+    assert!(response.body == "world");
   }
 
   #[test]
@@ -425,7 +425,7 @@ mod tests {
 
     let response = testing::get(app, "/test/123");
 
-    assert!(response == "123");
+    assert!(response.body == "123");
   }
 
   #[test]
@@ -444,7 +444,7 @@ mod tests {
 
     let response = testing::get(app2, "/test/123");
 
-    assert!(response == "123");
+    assert!(response.body == "123");
   }
 
   #[test]
@@ -463,7 +463,7 @@ mod tests {
 
     let response = testing::get(app2, "/test/123");
 
-    assert!(response == "123");
+    assert!(response.body == "123");
   }
 
   #[test]
@@ -488,7 +488,7 @@ mod tests {
 
     let response = testing::get(app2, "/test/123");
 
-    assert!(response == "123");
+    assert!(response.body == "123");
   }
 
   #[test]
@@ -513,7 +513,7 @@ mod tests {
 
     let response = testing::get(app2, "/test/");
 
-    assert!(response == "-1");
+    assert!(response.body == "-1");
   }
 
   #[test]
@@ -529,7 +529,7 @@ mod tests {
 
     let response = testing::get(app, "/test/1/");
 
-    assert!(response == "1");
+    assert!(response.body == "1");
   }
 
   #[test]
@@ -557,8 +557,7 @@ mod tests {
 
     let response = testing::post(app, "/test", "{\"key\":\"value\"}");
 
-    println!("response: {}", response);
-    assert!(response == "value");
+    assert!(response.body == "value");
   }
 
   #[test]
@@ -580,7 +579,7 @@ mod tests {
 
     let response = testing::get(app, "/test");
 
-    assert!(response == "1");
+    assert!(response.body == "1");
   }
 
   #[test]
@@ -608,7 +607,7 @@ mod tests {
 
     let response = testing::get(app, "/test");
 
-    assert!(response == "212");
+    assert!(response.body == "212");
   }
 
   #[test]
@@ -624,7 +623,7 @@ mod tests {
 
     let response = testing::get(app, "/test");
 
-    assert!(response == "Hello world");
+    assert!(response.body == "Hello world");
   }
 
   #[test]
@@ -653,7 +652,7 @@ mod tests {
 
     let response = testing::get(app, "/test");
 
-    assert!(response == "agnostic-1");
+    assert!(response.body == "agnostic-1");
   }
 
   #[test]
@@ -672,7 +671,7 @@ mod tests {
 
     let response = testing::get(app2, "/test");
 
-    assert!(response == "1");
+    assert!(response.body == "1");
   }
 
   #[test]
@@ -691,7 +690,7 @@ mod tests {
 
     let response = testing::get(app2, "/a");
 
-    assert!(response == "1");
+    assert!(response.body == "1");
   }
 
   #[test]
@@ -710,7 +709,7 @@ mod tests {
 
     let response = testing::get(app2, "/sub/test");
 
-    assert!(response == "1");
+    assert!(response.body == "1");
   }
 
   #[test]
@@ -729,7 +728,7 @@ mod tests {
 
     let response = testing::get(app2, "/sub");
 
-    assert!(response == "1");
+    assert!(response.body == "1");
   }
 
   #[test]
@@ -751,7 +750,7 @@ mod tests {
 
     let response = testing::get(app, "/not_found");
 
-    assert!(response == "not found");
+    assert!(response.body == "not found");
   }
 
 
@@ -774,7 +773,7 @@ mod tests {
 
     let response = testing::get(app, "/");
 
-    assert!(response == "not found");
+    assert!(response.body == "not found");
   }
 
   #[test]
@@ -796,7 +795,7 @@ mod tests {
 
     let response = testing::get(app, "/a/not_found/");
 
-    assert!(response == "not found");
+    assert!(response.body == "not found");
   }
 
   #[test]
@@ -818,7 +817,7 @@ mod tests {
 
     let response = testing::get(app, "/a/1/d");
 
-    assert!(response == "not found");
+    assert!(response.body == "not found");
   }
 
   #[test]
@@ -840,7 +839,7 @@ mod tests {
 
     let response = testing::get(app, "/a/1/d/e/f/g");
 
-    assert!(response == "not found");
+    assert!(response.body == "not found");
   }
 
 #[test]
@@ -866,7 +865,7 @@ mod tests {
 
     let response = testing::get(app3, "/a/1/d");
 
-    assert!(response == "not found");
+    assert!(response.body == "not found");
   }
 
   #[test]
@@ -882,7 +881,7 @@ mod tests {
 
     let response = testing::get(app, "/a/1/d/e/f/g");
 
-    assert!(response == "1");
+    assert!(response.body == "1");
   }
 
   #[test]
@@ -900,7 +899,7 @@ mod tests {
 
     let response = testing::get(app2, "/a/1/d/e/f/g");
 
-    assert!(response == "1");
+    assert!(response.body == "1");
   }
 
   #[test]
@@ -926,6 +925,6 @@ mod tests {
 
     let response = testing::get(app3, "/a/1/d/e/f/g");
 
-    assert!(response == "1");
+    assert!(response.body == "1");
   }
 }

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -1,10 +1,12 @@
 use app::App;
 use context::Context;
 use bytes::{BytesMut, BufMut};
-use request::{decode};
-use futures::{future, Future};
+use request::decode;
+use futures::Future;
+use std::collections::HashMap;
+use response::{Response, StatusMessage};
 
-pub fn get<T: Context + Send>(app: App<T>, route: &str) -> String {
+pub fn get<T: Context + Send>(app: App<T>, route: &str) -> TestResponse {
   let body = format!("GET {} HTTP/1.1\nHost: localhost:8080\n\n", route);
 
   let mut bytes = BytesMut::with_capacity(body.len());
@@ -14,10 +16,10 @@ pub fn get<T: Context + Send>(app: App<T>, route: &str) -> String {
   let request = decode(&mut bytes).unwrap().unwrap();
   let response = app.resolve(request).wait().unwrap();
 
-  String::from_utf8(response.response).unwrap()
+  TestResponse::new(response)
 }
 
-pub fn delete<T: Context + Send>(app: App<T>, route: &str) -> String {
+pub fn delete<T: Context + Send>(app: App<T>, route: &str) -> TestResponse {
   let body = format!("DELETE {} HTTP/1.1\nHost: localhost:8080\n\n", route);
 
   let mut bytes = BytesMut::with_capacity(body.len());
@@ -27,10 +29,10 @@ pub fn delete<T: Context + Send>(app: App<T>, route: &str) -> String {
   let request = decode(&mut bytes).unwrap().unwrap();
   let response = app.resolve(request).wait().unwrap();
 
-  String::from_utf8(response.response).unwrap()
+  TestResponse::new(response)
 }
 
-pub fn post<T: Context + Send>(app: App<T>, route: &str, content: &str) -> String {
+pub fn post<T: Context + Send>(app: App<T>, route: &str, content: &str) -> TestResponse {
   let body = format!("POST {} HTTP/1.1\nHost: localhost:8080\nContent-Length: {}\n\n{}", route, content.len(), content);
 
   let mut bytes = BytesMut::with_capacity(body.len());
@@ -40,10 +42,10 @@ pub fn post<T: Context + Send>(app: App<T>, route: &str, content: &str) -> Strin
   let request = decode(&mut bytes).unwrap().unwrap();
   let response = app.resolve(request).wait().unwrap();
 
-  String::from_utf8(response.response).unwrap()
+  TestResponse::new(response)
 }
 
-pub fn put<T: Context + Send>(app: App<T>, route: &str, content: &str) -> String {
+pub fn put<T: Context + Send>(app: App<T>, route: &str, content: &str) -> TestResponse {
   let body = format!("PUT {} HTTP/1.1\nHost: localhost:8080\nContent-Length: {}\n\n{}", route, content.len(), content);
 
   let mut bytes = BytesMut::with_capacity(body.len());
@@ -53,10 +55,10 @@ pub fn put<T: Context + Send>(app: App<T>, route: &str, content: &str) -> String
   let request = decode(&mut bytes).unwrap().unwrap();
   let response = app.resolve(request).wait().unwrap();
 
-  String::from_utf8(response.response).unwrap()
+  TestResponse::new(response)
 }
 
-pub fn update<T: Context + Send>(app: App<T>, route: &str, content: &str) -> String {
+pub fn update<T: Context + Send>(app: App<T>, route: &str, content: &str) -> TestResponse {
   let body = format!("UPDATE {} HTTP/1.1\nHost: localhost:8080\nContent-Length: {}\n\n{}", route, content.len(), content);
 
   let mut bytes = BytesMut::with_capacity(body.len());
@@ -66,5 +68,37 @@ pub fn update<T: Context + Send>(app: App<T>, route: &str, content: &str) -> Str
   let request = decode(&mut bytes).unwrap().unwrap();
   let response = app.resolve(request).wait().unwrap();
 
-  String::from_utf8(response.response).unwrap()
+  TestResponse::new(response)
+}
+
+pub struct TestResponse {
+  pub body: String,
+  pub headers: HashMap<String, String>,
+  pub status: (String, u32)
+}
+
+impl TestResponse {
+  fn new(response: Response) -> TestResponse {
+    let mut headers = HashMap::new();
+    let header_string = String::from_utf8(response.header_raw.to_vec()).unwrap();
+
+    for header_pair in header_string.split("\r\n") {
+      if header_pair.len() > 0 {
+        let mut split = header_pair.split(":");
+        let key = split.next().unwrap().trim().to_owned();
+        let value = split.next().unwrap().trim().to_owned();
+
+        headers.insert(key, value);
+      }
+    }
+
+    TestResponse {
+      body: String::from_utf8(response.response).unwrap(),
+      headers: headers,
+      status: match response.status_message {
+        StatusMessage::Ok => ("Ok".to_owned(), 200),
+        StatusMessage::Custom(code, message) => (message, code)
+      }
+    }
+  }
 }


### PR DESCRIPTION
Replaces the output with a `TestResponse` struct instead of a single string. The test struct has `body` for the body, `headers` for the headers, and `status` as a pair of code and message.

Resolves #65 