### PR TITLE
bug: Refreshing in Chrome causes `ERR_EMPTY_RESPONSE`

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -113,6 +113,8 @@ impl<T: Context + Send> App<T> {
     let arc_app = Arc::new(app);
 
     fn process<T: Context + Send>(app: Arc<App<T>>, socket: TcpStream) {
+      println!("Processing...");
+
       let framed = Framed::new(socket, Http);
       let (tx, rx) = framed.split();
 


### PR DESCRIPTION
**Issue:** When in chrome, loading the page once in the `most_basic` example loads successfully. Subsequent refreshes yield `ERR_EMPTY_RESPONSE`.

**Solution:** This was happening because we had too small a vector for headers. Chrome, for one reason or another, treats the first and refresh requests differently as far as headers go. This is also why we were not seeing the issue in tests or in using `curl`. The header size array has been increased to 32 now.

Resolves #67 