### PR TITLE
feat: Give BasicContext more functionality

### DIFF
--- a/examples/cookies/main.rs
+++ b/examples/cookies/main.rs
@@ -1,0 +1,32 @@
+extern crate thruster;
+extern crate futures;
+
+use std::boxed::Box;
+use futures::future;
+
+use thruster::{App, BasicContext as Ctx, CookieOptions, MiddlewareChain, MiddlewareReturnValue};
+
+fn plaintext(mut context: Ctx, _chain: &MiddlewareChain<Ctx>) -> MiddlewareReturnValue<Ctx> {
+  let val = "Hello, World!".to_owned();
+  context.body = val;
+  context.cookie("SomeCookie", "Some Value!", CookieOptions::default());
+
+  Box::new(future::ok(context))
+}
+
+fn redirect(mut context: Ctx, _chain: &MiddlewareChain<Ctx>) -> MiddlewareReturnValue<Ctx> {
+  context.redirect("/plaintext");
+
+  Box::new(future::ok(context))
+}
+
+fn main() {
+  println!("Starting server...");
+
+  let mut app = App::<Ctx>::new();
+
+  app.get("/plaintext", vec![plaintext]);
+  app.get("*", vec![redirect]);
+
+  App::start(app, "0.0.0.0", 4321);
+}

--- a/src/app.rs
+++ b/src/app.rs
@@ -113,8 +113,6 @@ impl<T: Context + Send> App<T> {
     let arc_app = Arc::new(app);
 
     fn process<T: Context + Send>(app: Arc<App<T>>, socket: TcpStream) {
-      println!("Processing...");
-
       let framed = Framed::new(socket, Http);
       let (tx, rx) = framed.split();
 

--- a/src/builtins/basic_context.rs
+++ b/src/builtins/basic_context.rs
@@ -6,20 +6,52 @@ use request::Request;
 use builtins::retains_request::RetainsRequest;
 use builtins::query_params::HasQueryParams;
 
-pub fn generate_context(request: Request) -> BasicContext {
-  BasicContext {
-    body: "".to_owned(),
-    params: request.params().clone(),
-    request: request,
-    query_params: HashMap::new()
+pub enum SameSite {
+  Strict,
+  Lax
+}
+
+pub struct CookieOptions {
+  pub domain: String,
+  pub path: String,
+  pub expires: u64,
+  pub http_only: bool,
+  pub max_age: u64,
+  pub secure: bool,
+  pub signed: bool,
+  pub same_site: SameSite
+}
+
+impl CookieOptions {
+  pub fn default() -> CookieOptions {
+    CookieOptions {
+      domain: "".to_owned(),
+      path: "/".to_owned(),
+      expires: 0,
+      http_only: false,
+      max_age: 0,
+      secure: false,
+      signed: false,
+      same_site: SameSite::Strict
+    }
   }
+}
+
+pub fn generate_context(request: Request) -> BasicContext {
+  let mut ctx = BasicContext::new();
+  ctx.params = request.params().clone();
+  ctx.request = request;
+
+  ctx
 }
 
 pub struct BasicContext {
   pub body: String,
   pub params: HashMap<String, String>,
   pub query_params: HashMap<String, String>,
-  pub request: Request
+  pub request: Request,
+  pub status: u32,
+  pub headers: HashMap<String, String>
 }
 
 impl BasicContext {
@@ -28,8 +60,100 @@ impl BasicContext {
       body: "".to_owned(),
       params: HashMap::new(),
       query_params: HashMap::new(),
-      request: Request::new()
+      request: Request::new(),
+      headers: HashMap::new(),
+      status: 200
     }
+  }
+
+  ///
+  /// Set a header on the response
+  ///
+  pub fn set(&mut self, key: &str, value: &str) {
+    self.headers.insert(key.to_owned(), value.to_owned());
+  }
+
+  ///
+  /// Remove a header on the response
+  ///
+  pub fn remove(&mut self, key: &str) {
+    self.headers.remove(key);
+  }
+
+  ///
+  /// Set the response status code
+  ///
+  pub fn status(&mut self, code: u32) {
+    self.status = code;
+  }
+
+  ///
+  /// Set the response `Content-Type`. A shortcode for
+  ///
+  /// ```ignore
+  /// ctx.set("Content-Type", "some-val");
+  /// ```
+  ///
+  pub fn content_type(&mut self, c_type: &str) {
+    self.set("Content-Type", c_type);
+  }
+
+  ///
+  /// Set up a redirect, will default to 302, but can be changed after
+  /// the fact.
+  ///
+  /// ```ignore
+  /// ctx.set("Location", "/some-path");
+  /// ctx.status(302);
+  /// ```
+  ///
+  pub fn redirect(&mut self, destination: &str) {
+    self.status(302);
+
+    self.set("Location", destination);
+  }
+
+  ///
+  /// Sets a cookie on the response
+  ///
+  pub fn cookie(&mut self, name: &str, value: &str, options: CookieOptions) {
+    let cookie_value = match self.headers.get("Set-Cookie") {
+      Some(val) => format!("{}, {}", val, self.cookify_options(name, value, options)),
+      None => self.cookify_options(name, value, options)
+    };
+
+    self.set("Set-Cookie", &cookie_value);
+  }
+
+  fn cookify_options(&self, name: &str, value: &str, options: CookieOptions) -> String {
+    let mut pieces = vec![format!("Path={}", options.path)];
+
+    if options.expires > 0 {
+      pieces.push(format!("Expires={}", options.expires));
+    }
+
+    if options.max_age > 0 {
+      pieces.push(format!("Max-Age={}", options.max_age));
+    }
+
+    if options.domain.len() > 0 {
+      pieces.push(format!("Domain={}", options.domain));
+    }
+
+    if options.secure {
+      pieces.push("Secure".to_owned());
+    }
+
+    if options.http_only {
+      pieces.push("HttpOnly".to_owned());
+    }
+
+    match options.same_site {
+      SameSite::Strict => pieces.push("SameSite=Strict".to_owned()),
+      SameSite::Lax => pieces.push("SameSite=Lax".to_owned())
+    };
+
+    format!("{}={}; {}", name, value, pieces.join(", "))
   }
 }
 
@@ -38,6 +162,12 @@ impl Context for BasicContext {
     let mut response = Response::new();
 
     response.body(&self.body);
+
+    for (key, val) in self.headers {
+      response.header(&key, &val);
+    }
+
+    response.status_code(self.status, "");
 
     response
   }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@ mod route_tree;
 pub use app::App;
 pub use context::Context;
 pub use builtins::basic_context::BasicContext;
+pub use builtins::basic_context::CookieOptions;
 pub use middleware::{Middleware, MiddlewareChain, MiddlewareReturnValue};
 pub use response::{encode, Response};
 pub use request::{decode, Request};

--- a/src/request.rs
+++ b/src/request.rs
@@ -94,8 +94,6 @@ impl fmt::Debug for Request {
 
 
 pub fn decode(buf: &mut BytesMut) -> io::Result<Option<Request>> {
-    println!("buf: {}", String::from_utf8(buf.to_vec()).unwrap());
-
     // TODO: we should grow this headers array if parsing fails and asks
     //       for more headers
     let (method, path, version, headers, amt, body_len) = {


### PR DESCRIPTION
This gives `BasicContext` more functionality. Specifically:
- `set` Sets a header
- `remove` Removes a header
- `status` Sets the status
- `content_type` Sets the `Content-Type` header (a convenience method for `set("Content-Type", "whatever")`
- `redirect` Sets the status code to 302 if not 301 (can be changed after,) and the `Location` header.
- `cookie` Sets a cookie

Resolves #70