### PR TITLE
bug: Fix index route conflict with *

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -394,6 +394,28 @@ mod tests {
     assert!(response.body == "1");
   }
 
+  #[test]
+  fn it_should_correctly_differentiate_wildcards_and_valid_routes() {
+    let mut app = App::<BasicContext>::new();
+
+    fn test_fn_1(mut context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+      context.body = "1".to_owned();
+      Box::new(future::ok(context))
+    };
+
+    fn test_fn_404(mut context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+      context.body = "2".to_owned();
+      Box::new(future::ok(context))
+    };
+
+
+    app.get("/", vec![test_fn_1]);
+    app.get("/*", vec![test_fn_404]);
+
+    let response = testing::get(app, "/");
+
+    assert!(response.body == "1");
+  }
 
   #[test]
   fn it_should_handle_query_parameters() {
@@ -517,7 +539,7 @@ mod tests {
   }
 
   #[test]
-  fn it_should_trim_trailing_slashes_after_params() {
+  fn itz_should_trim_trailing_slashes_after_params() {
     let mut app = App::<BasicContext>::new();
 
     fn test_fn_1(mut context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> MiddlewareReturnValue<BasicContext> {
@@ -878,6 +900,11 @@ mod tests {
     };
 
     app.get("*", vec![test_fn_1]);
+
+    println!("app: {}", app._route_parser.route_tree.root_node.to_string(""));
+    for (route, middleware) in app._route_parser.route_tree.root_node.enumerate() {
+      println!("{}: {}", route, middleware.len());
+    }
 
     let response = testing::get(app, "/a/1/d/e/f/g");
 

--- a/src/route_tree/mod.rs
+++ b/src/route_tree/mod.rs
@@ -68,14 +68,14 @@ impl<T: Context + Send> RouteTree<T> {
 
   pub fn add_route(&mut self, route: &str, middleware: SmallVec<[Middleware<T>; 8]>) {
     // We have to merge /* down into the root nodes so it applies as a wildcard
-    match route {
-      "__GET__/*" => self.specific_root_node.add_route(method_to_prefix(Method::GET), middleware.clone()),
-      "__POST__/*" => self.specific_root_node.add_route(method_to_prefix(Method::POST), middleware.clone()),
-      "__PUT__/*" => self.specific_root_node.add_route(method_to_prefix(Method::PUT), middleware.clone()),
-      "__UPDATE__/*" => self.specific_root_node.add_route(method_to_prefix(Method::UPDATE), middleware.clone()),
-      "__DELETE__/*" => self.specific_root_node.add_route(method_to_prefix(Method::DELETE), middleware.clone()),
-      _ => ()
-    };
+    // match route {
+    //   "__GET__/*" => self.specific_root_node.add_route(method_to_prefix(Method::GET), middleware.clone()),
+    //   "__POST__/*" => self.specific_root_node.add_route(method_to_prefix(Method::POST), middleware.clone()),
+    //   "__PUT__/*" => self.specific_root_node.add_route(method_to_prefix(Method::PUT), middleware.clone()),
+    //   "__UPDATE__/*" => self.specific_root_node.add_route(method_to_prefix(Method::UPDATE), middleware.clone()),
+    //   "__DELETE__/*" => self.specific_root_node.add_route(method_to_prefix(Method::DELETE), middleware.clone()),
+    //   _ => ()
+    // };
 
     self.specific_root_node.add_route(route, middleware);
     self.update_root_node();


### PR DESCRIPTION
**Issue:** If `/` is defined as well as `/*`, the wildcard takes precedence, where the opposite should be true.

**Solution:** The matching algorithm was off. We should reexamine and refactor the matching algorithm in the future.

[Fixes #73]