### PR TITLE
feat: Allow for generic backends

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thruster"
-version = "0.5.0-beta10"
+version = "0.5.0"
 authors = ["Pete Mertz <peter.s.mertz@gmail.com>"]
 description = "A middleware based http async web server."
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Pete Mertz <peter.s.mertz@gmail.com>"]
 description = "A middleware based http async web server."
 readme = "README.md"
 license = "MIT"
+keywords = ["thruster", "router", "fast", "http", "hyper"]
 documentation = "https://thruster.github.com"
 homepage = "https://thruster.github.com"
 repository = "https://github.com/trezm/thruster"
@@ -16,11 +17,16 @@ debug = true
 name = "app"
 harness = false
 
+[features]
+default = ["hyper_server"]
+hyper_server = ["hyper"]
+
 [dependencies]
 bytes = "0.4"
 futures = "0.1.23"
 http = "0.1.7"
 httparse = "1.1.2"
+hyper = { version = "0.12.10", optional = true }
 log = "0.3.6"
 net2 = "0.2"
 num_cpus = "1.0"

--- a/examples/diesel/context.rs
+++ b/examples/diesel/context.rs
@@ -21,6 +21,8 @@ impl Ctx {
 }
 
 impl Context for Ctx {
+  type Response = Response;
+
   fn get_response(mut self) -> Response {
     self.response.status_code(200, "OK");
 

--- a/examples/diesel/main.rs
+++ b/examples/diesel/main.rs
@@ -16,6 +16,8 @@ mod content_model;
 use futures::future;
 
 use thruster::{App, MiddlewareChain, MiddlewareReturnValue};
+use thruster::builtins::server::Server;
+use thruster::server::ThrusterServer;
 use context::{Ctx, generate_context};
 use diesel::prelude::*;
 use diesel::pg::PgConnection;
@@ -68,5 +70,6 @@ fn main() {
   app.get("/plaintext", vec![fetch_value]);
   app.get("/*", vec![not_found_404]);
 
-  App::start(app, "0.0.0.0", 4321);
+  let server = Server::new(app);
+  server.start("0.0.0.0", 4321);
 }

--- a/examples/hello_world/context.rs
+++ b/examples/hello_world/context.rs
@@ -33,6 +33,8 @@ impl Ctx {
 }
 
 impl Context for Ctx {
+  type Response = Response;
+
   fn get_response(mut self) -> Response {
     self.response.status_code(200, "OK");
 

--- a/examples/hello_world/main.rs
+++ b/examples/hello_world/main.rs
@@ -12,6 +12,8 @@ mod context;
 use futures::future;
 
 use thruster::{App, MiddlewareChain, MiddlewareReturnValue};
+use thruster::builtins::server::Server;
+use thruster::server::ThrusterServer;
 use context::{generate_context, Ctx};
 
 fn not_found_404(context: Ctx, _chain: &MiddlewareChain<Ctx>) -> MiddlewareReturnValue<Ctx> {
@@ -63,5 +65,6 @@ fn main() {
 
   app.get("/*", vec![not_found_404]);
 
-  App::start(app, "0.0.0.0", 4321);
+  let server = Server::new(app);
+  server.start("0.0.0.0", 4321);
 }

--- a/examples/most_basic.rs
+++ b/examples/most_basic.rs
@@ -4,7 +4,9 @@ extern crate futures;
 use std::boxed::Box;
 use futures::future;
 
-use thruster::{App, BasicContext as Ctx, MiddlewareChain, MiddlewareReturnValue};
+use thruster::{App, BasicContext as Ctx, MiddlewareChain, MiddlewareReturnValue, Request};
+use thruster::builtins::server::Server;
+use thruster::server::ThrusterServer;
 
 fn plaintext(mut context: Ctx, _chain: &MiddlewareChain<Ctx>) -> MiddlewareReturnValue<Ctx> {
   let val = "Hello, World!".to_owned();
@@ -16,9 +18,10 @@ fn plaintext(mut context: Ctx, _chain: &MiddlewareChain<Ctx>) -> MiddlewareRetur
 fn main() {
   println!("Starting server...");
 
-  let mut app = App::<Ctx>::new();
+  let mut app = App::<Request, Ctx>::new();
 
   app.get("/plaintext", vec![plaintext]);
 
-  App::start(app, "0.0.0.0", 4321);
+  let server = Server::new(app);
+  server.start("0.0.0.0", 4321);
 }

--- a/examples/run_test/main.rs
+++ b/examples/run_test/main.rs
@@ -4,7 +4,7 @@ extern crate futures;
 use std::boxed::Box;
 use futures::future;
 
-use thruster::{testing, App, BasicContext as Ctx, MiddlewareChain, MiddlewareReturnValue};
+use thruster::{testing, App, BasicContext as Ctx, MiddlewareChain, MiddlewareReturnValue, Request};
 
 fn plaintext(mut context: Ctx, _chain: &MiddlewareChain<Ctx>) -> MiddlewareReturnValue<Ctx> {
   let val = "Hello, World!".to_owned();
@@ -14,7 +14,7 @@ fn plaintext(mut context: Ctx, _chain: &MiddlewareChain<Ctx>) -> MiddlewareRetur
 }
 
 fn main() {
-  let mut app = App::<Ctx>::new();
+  let mut app = App::<Request, Ctx>::new();
 
   app.get("/plaintext", vec![plaintext]);
 

--- a/src/builtins/hyper_server.rs
+++ b/src/builtins/hyper_server.rs
@@ -1,0 +1,65 @@
+use std::net::ToSocketAddrs;
+use std::collections::HashMap;
+
+use futures::Future;
+use tokio;
+use hyper::{Body, Response, Request, Server as HyperServer};
+use hyper::service::service_fn;
+use std::sync::Arc;
+
+use app::App;
+use context::Context;
+use server::ThrusterServer;
+use request::RequestWithParams;
+
+impl<Body> RequestWithParams for Request<Body> {
+  fn set_params(&mut self, params: HashMap<String, String>) {
+    let extensions = self
+      .extensions_mut();
+
+    extensions.insert(params);
+  }
+}
+
+pub struct Server<T: 'static + Context + Send> {
+  app: App<Request<Body>, T>
+}
+
+impl<T: 'static + Context + Send> Server<T> {
+}
+
+impl<T: Context<Response = Response<Body>> + Send> ThrusterServer for Server<T> {
+  type Context = T;
+  type Response = Response<Body>;
+  type Request = Request<Body>;
+
+  fn new(app: App<Self::Request, T>) -> Self {
+    Server {
+      app: app
+    }
+  }
+
+  fn start(mut self, host: &str, port: u16) {
+    let addr = (host, port).to_socket_addrs().unwrap().next().unwrap();
+
+    self.app._route_parser.optimize();
+    let arc_app = Arc::new(self.app);
+
+    let new_service = move || {
+      let clone = arc_app.clone();
+      service_fn(move |req: Request<Body>| {
+        let matched = clone.resolve_from_method_and_path(
+          &req.method().to_string(),
+          &req.uri().to_string()
+        );
+        clone.resolve(req, matched)
+      })
+    };
+
+    let server = HyperServer::bind(&addr)
+      .serve(new_service)
+      .map_err(|e| eprintln!("server error: {}", e));
+
+    tokio::run(server);
+  }
+}

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -1,4 +1,10 @@
 pub mod send;
 pub mod query_params;
-pub mod retains_request;
 pub mod basic_context;
+
+pub mod server;
+
+#[cfg(feature="hyper_server")]
+pub mod hyper_server;
+#[cfg(feature="hyper_server")]
+pub mod basic_hyper_context;

--- a/src/builtins/query_params.rs
+++ b/src/builtins/query_params.rs
@@ -2,17 +2,17 @@ use std::collections::HashMap;
 
 use context::Context;
 use middleware::{MiddlewareChain, MiddlewareReturnValue};
-use builtins::retains_request::RetainsRequest;
 
 pub trait HasQueryParams {
   fn set_query_params(&mut self, query_params: HashMap<String, String>);
+  fn route(&self) -> &str;
 }
 
-pub fn query_params<T: 'static + Context + HasQueryParams + RetainsRequest + Send>(mut context: T, chain: &MiddlewareChain<T>) -> MiddlewareReturnValue<T> {
+pub fn query_params<T: 'static + Context + HasQueryParams + Send>(mut context: T, chain: &MiddlewareChain<T>) -> MiddlewareReturnValue<T> {
   let mut query_param_hash = HashMap::new();
 
   {
-    let route: &str = &context.get_request().path();
+    let route: &str = &context.route();
 
     let mut iter = route.split("?");
     // Get rid of first bit (the non-query string part)

--- a/src/builtins/retains_request.rs
+++ b/src/builtins/retains_request.rs
@@ -1,5 +1,0 @@
-use request::Request;
-
-pub trait RetainsRequest {
-  fn get_request<'a>(&'a self) -> &'a Request;
-}

--- a/src/builtins/server.rs
+++ b/src/builtins/server.rs
@@ -1,0 +1,156 @@
+use std::net::ToSocketAddrs;
+
+use futures::future;
+use futures::Future;
+use tokio;
+use tokio::net::{TcpStream, TcpListener};
+use tokio::prelude::*;
+use tokio_codec::Framed;
+use num_cpus;
+use net2::TcpBuilder;
+#[cfg(not(windows))]
+use net2::unix::UnixTcpBuilderExt;
+use std::thread;
+
+use std::sync::Arc;
+
+use app::App;
+use context::Context;
+use http::Http;
+use response::Response;
+use request::Request;
+use server::ThrusterServer;
+
+pub struct Server<T: 'static + Context<Response = Response> + Send> {
+  app: App<Request, T>
+}
+
+impl<T: 'static + Context<Response = Response> + Send> Server<T> {
+  ///
+  /// Starts the app with the default tokio runtime execution model
+  ///
+  pub fn start_work_stealing_optimized(self, host: &str, port: u16) {
+    use server::ThrusterServer;
+
+    self.start(host, port);
+  }
+
+  ///
+  /// Starts the app with a thread pool optimized for small requests and quick timeouts. This
+  /// is done internally by spawning a separate thread for each reactor core. This is valuable
+  /// if all server endpoints are similar in their load, as work is divided evenly among threads.
+  /// As seanmonstar points out though, this is a very specific use case and might not be useful
+  /// for everyday work loads.alloc
+  ///
+  /// See the discussion here for more information:
+  ///
+  /// https://users.rust-lang.org/t/getting-tokio-to-match-actix-web-performance/18659/7
+  ///
+  pub fn start_small_load_optimized(mut self, host: &str, port: u16) {
+    let addr = (host, port).to_socket_addrs().unwrap().next().unwrap();
+    let mut threads = Vec::new();
+    self.app._route_parser.optimize();
+    let arc_app = Arc::new(self.app);
+
+    for _ in 0..num_cpus::get() {
+      let arc_app = arc_app.clone();
+      threads.push(thread::spawn(move || {
+        let mut runtime = tokio::runtime::current_thread::Runtime::new().unwrap();
+
+        let server = future::lazy(move || {
+          let listener = {
+            let builder = TcpBuilder::new_v4().unwrap();
+            #[cfg(not(windows))]
+            builder.reuse_address(true).unwrap();
+            #[cfg(not(windows))]
+            builder.reuse_port(true).unwrap();
+            builder.bind(addr).unwrap();
+            builder.listen(2048).unwrap()
+          };
+          let listener = TcpListener::from_std(listener, &tokio::reactor::Handle::current()).unwrap();
+
+          listener.incoming().for_each(move |socket| {
+            process(Arc::clone(&arc_app), socket);
+            Ok(())
+          })
+          .map_err(|err| eprintln!("accept error = {:?}", err))
+        });
+
+        runtime.spawn(server);
+        runtime.run().unwrap();
+      }));
+    }
+
+    println!("Server running on {}", addr);
+
+    for thread in threads {
+      thread.join().unwrap();
+    }
+
+    use request::Request;
+    use response::Response;
+    fn process<T: Context<Response = Response> + Send>(app: Arc<App<Request, T>>, socket: TcpStream) {
+      let framed = Framed::new(socket, Http);
+      let (tx, rx) = framed.split();
+
+      let task = tx.send_all(rx.and_then(move |request: Request| {
+            let matched = app.resolve_from_method_and_path(request.method(), request.path());
+            app.resolve(request, matched)
+          }))
+          .then(|_| future::ok(()));
+
+      // Spawn the task that handles the connection.
+      tokio::spawn(task);
+    }
+  }
+}
+
+impl<T: Context<Response = Response> + Send> ThrusterServer for Server<T> {
+  type Context = T;
+  type Response = Response;
+  type Request = Request;
+
+  fn new(app: App<Self::Request, T>) -> Self {
+    Server {
+      app: app
+    }
+  }
+
+  ///
+  /// Alias for start_work_stealing_optimized
+  ///
+  fn start(mut self, host: &str, port: u16) {
+    let addr = (host, port).to_socket_addrs().unwrap().next().unwrap();
+
+    self.app._route_parser.optimize();
+
+    let listener = TcpListener::bind(&addr).unwrap();
+    let arc_app = Arc::new(self.app);
+
+    use request::Request;
+    use response::Response;
+    fn process<T: Context<Response = Response> + Send>(app: Arc<App<Request, T>>, socket: TcpStream) {
+      let framed = Framed::new(socket, Http);
+      let (tx, rx) = framed.split();
+
+      let task = tx.send_all(rx.and_then(move |request: Request| {
+            let matched = app.resolve_from_method_and_path(request.method(), request.path());
+            app.resolve(request, matched)
+          }))
+          .then(|_| future::ok(()));
+
+      // Spawn the task that handles the connection.
+      tokio::spawn(task);
+    }
+
+    let server = listener.incoming()
+        .map_err(|e| println!("error = {:?}", e))
+        .for_each(move |socket| {
+            let _ = socket.set_nodelay(true);
+            process(arc_app.clone(), socket);
+            Ok(())
+        });
+
+    tokio::run(server);
+  }
+}

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,10 +1,10 @@
-use response::Response;
-
 /// A `Context` is what will be passed between functions in the middleware for
 /// the defined routes of Thruster. Since a new context is made for each
 /// incomming request, it's important to keep this struct lean and quick, as
 /// well as the `context_generator` associated with it.
 pub trait Context {
-  fn get_response(self) -> Response;
+  type Response: Send;
+
+  fn get_response(self) -> Self::Response;
   fn set_body(&mut self, String);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,9 @@ extern crate tokio;
 extern crate tokio_codec;
 extern crate tokio_io;
 
+#[cfg(feature="hyper_server")]
+extern crate hyper;
+
 #[macro_use] extern crate smallvec;
 #[macro_use] extern crate templatify;
 // For tests
@@ -23,6 +26,7 @@ extern crate tokio_core;
 
 mod app;
 pub mod builtins;
+pub mod server;
 mod context;
 mod date;
 mod http;
@@ -41,3 +45,6 @@ pub use response::{encode, Response};
 pub use request::{decode, Request};
 pub use http::Http;
 pub mod testing;
+
+#[cfg(feature="hyper_server")]
+pub use builtins::basic_hyper_context::BasicHyperContext;

--- a/src/request.rs
+++ b/src/request.rs
@@ -8,6 +8,11 @@ use smallvec::SmallVec;
 use httparse;
 use httplib;
 
+
+pub trait RequestWithParams {
+    fn set_params(&mut self, HashMap<String, String>);
+}
+
 pub struct Request {
     body: Slice,
     method: Slice,
@@ -80,8 +85,10 @@ impl Request {
     pub fn params(&self) -> &HashMap<String, String> {
         &self.params
     }
+}
 
-    pub fn set_params(&mut self, params: HashMap<String, String>) {
+impl RequestWithParams for Request {
+    fn set_params(&mut self, params: HashMap<String, String>) {
         self.params = params;
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,0 +1,12 @@
+use app::App;
+use context::Context;
+use request::RequestWithParams;
+
+pub trait ThrusterServer {
+  type Context: Context + Send;
+  type Response: Send;
+  type Request: RequestWithParams + Send;
+
+  fn new(App<Self::Request, Self::Context>) -> Self;
+  fn start(self, host: &str, port: u16);
+}

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -5,8 +5,9 @@ use request::decode;
 use futures::Future;
 use std::collections::HashMap;
 use response::{Response, StatusMessage};
+use request::Request;
 
-pub fn get<T: Context + Send>(app: App<T>, route: &str) -> TestResponse {
+pub fn get<T: Context<Response = Response> + Send>(app: App<Request, T>, route: &str) -> TestResponse {
   let body = format!("GET {} HTTP/1.1\nHost: localhost:8080\n\n", route);
 
   let mut bytes = BytesMut::with_capacity(body.len());
@@ -14,12 +15,13 @@ pub fn get<T: Context + Send>(app: App<T>, route: &str) -> TestResponse {
 
 
   let request = decode(&mut bytes).unwrap().unwrap();
-  let response = app.resolve(request).wait().unwrap();
+  let matched_route = app.resolve_from_method_and_path("GET", route);
+  let response = app.resolve(request, matched_route).wait().unwrap();
 
   TestResponse::new(response)
 }
 
-pub fn delete<T: Context + Send>(app: App<T>, route: &str) -> TestResponse {
+pub fn delete<T: Context<Response = Response> + Send>(app: App<Request, T>, route: &str) -> TestResponse {
   let body = format!("DELETE {} HTTP/1.1\nHost: localhost:8080\n\n", route);
 
   let mut bytes = BytesMut::with_capacity(body.len());
@@ -27,12 +29,14 @@ pub fn delete<T: Context + Send>(app: App<T>, route: &str) -> TestResponse {
 
 
   let request = decode(&mut bytes).unwrap().unwrap();
-  let response = app.resolve(request).wait().unwrap();
+  let matched_route = app.resolve_from_method_and_path("DELETE", route);
+  let response = app.resolve(request, matched_route).wait().unwrap();
+
 
   TestResponse::new(response)
 }
 
-pub fn post<T: Context + Send>(app: App<T>, route: &str, content: &str) -> TestResponse {
+pub fn post<T: Context<Response = Response> + Send>(app: App<Request, T>, route: &str, content: &str) -> TestResponse {
   let body = format!("POST {} HTTP/1.1\nHost: localhost:8080\nContent-Length: {}\n\n{}", route, content.len(), content);
 
   let mut bytes = BytesMut::with_capacity(body.len());
@@ -40,12 +44,14 @@ pub fn post<T: Context + Send>(app: App<T>, route: &str, content: &str) -> TestR
 
 
   let request = decode(&mut bytes).unwrap().unwrap();
-  let response = app.resolve(request).wait().unwrap();
+  let matched_route = app.resolve_from_method_and_path("POST", route);
+  let response = app.resolve(request, matched_route).wait().unwrap();
+
 
   TestResponse::new(response)
 }
 
-pub fn put<T: Context + Send>(app: App<T>, route: &str, content: &str) -> TestResponse {
+pub fn put<T: Context<Response = Response> + Send>(app: App<Request, T>, route: &str, content: &str) -> TestResponse {
   let body = format!("PUT {} HTTP/1.1\nHost: localhost:8080\nContent-Length: {}\n\n{}", route, content.len(), content);
 
   let mut bytes = BytesMut::with_capacity(body.len());
@@ -53,12 +59,14 @@ pub fn put<T: Context + Send>(app: App<T>, route: &str, content: &str) -> TestRe
 
 
   let request = decode(&mut bytes).unwrap().unwrap();
-  let response = app.resolve(request).wait().unwrap();
+  let matched_route = app.resolve_from_method_and_path("PUT", route);
+  let response = app.resolve(request, matched_route).wait().unwrap();
+
 
   TestResponse::new(response)
 }
 
-pub fn update<T: Context + Send>(app: App<T>, route: &str, content: &str) -> TestResponse {
+pub fn update<T: Context<Response = Response> + Send>(app: App<Request, T>, route: &str, content: &str) -> TestResponse {
   let body = format!("UPDATE {} HTTP/1.1\nHost: localhost:8080\nContent-Length: {}\n\n{}", route, content.len(), content);
 
   let mut bytes = BytesMut::with_capacity(body.len());
@@ -66,7 +74,9 @@ pub fn update<T: Context + Send>(app: App<T>, route: &str, content: &str) -> Tes
 
 
   let request = decode(&mut bytes).unwrap().unwrap();
-  let response = app.resolve(request).wait().unwrap();
+  let matched_route = app.resolve_from_method_and_path("UPDATE", route);
+  let response = app.resolve(request, matched_route).wait().unwrap();
+
 
   TestResponse::new(response)
 }


### PR DESCRIPTION
This allows the router to be functionally separated from the backend. Included is an example to use Hyper as the server backend with Thruster as a router over it.