### PR TITLE
feat: Move `set_body` to accept a `Vec<u8>`

### DIFF
--- a/examples/diesel/context.rs
+++ b/examples/diesel/context.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap};
+use std::str;
 use smallvec::SmallVec;
 
 use thruster::{Context, Response, Request};
@@ -31,8 +32,8 @@ impl Context for Ctx {
     self.response
   }
 
-  fn set_body(&mut self, body: String) {
-    self.body = body;
+  fn set_body(&mut self, body: Vec<u8>) {
+    self.body = str::from_utf8(&body).unwrap_or("").to_owned();
   }
 }
 

--- a/examples/hello_world/context.rs
+++ b/examples/hello_world/context.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap};
+use std::str;
 use smallvec::SmallVec;
 use thruster::{Context, Request, Response};
 
@@ -43,8 +44,8 @@ impl Context for Ctx {
     self.response
   }
 
-  fn set_body(&mut self, body: String) {
-    self.body = body;
+  fn set_body(&mut self, body: Vec<u8>) {
+    self.body = str::from_utf8(&body).unwrap_or("").to_owned();
   }
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -220,6 +220,7 @@ mod tests {
   use futures::{future, Future};
   use std::boxed::Box;
   use std::io;
+  use std::str;
   use std::marker::Send;
   use builtins::query_params;
   use builtins::basic_context::BasicContext;
@@ -252,8 +253,8 @@ mod tests {
       response
     }
 
-    fn set_body(&mut self, body: String) {
-      self.body = body;
+    fn set_body(&mut self, body: Vec<u8>) {
+      self.body = str::from_utf8(&body).unwrap_or("").to_owned();
     }
   }
 
@@ -450,7 +451,7 @@ mod tests {
     fn test_fn_1(mut context: TypedContext<TestStruct>, _chain: &MiddlewareChain<TypedContext<TestStruct>>) -> Box<Future<Item=TypedContext<TestStruct>, Error=io::Error> + Send> {
       let value = context.request_body.key.clone();
 
-      context.set_body(value);
+      context.set_body(value.as_bytes().to_vec());
 
       Box::new(future::ok(context))
     };

--- a/src/builtins/basic_context.rs
+++ b/src/builtins/basic_context.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::str;
 
 use context::Context;
 use response::Response;
@@ -174,8 +175,8 @@ impl Context for BasicContext {
     response
   }
 
-  fn set_body(&mut self, body: String) {
-    self.body = body;
+  fn set_body(&mut self, body: Vec<u8>) {
+    self.body = str::from_utf8(&body).unwrap_or("").to_owned();
   }
 }
 

--- a/src/builtins/basic_hyper_context.rs
+++ b/src/builtins/basic_hyper_context.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::str;
 use hyper::{Body, Response, Request, StatusCode};
 
 use context::Context;
@@ -188,8 +189,8 @@ impl Context for BasicHyperContext {
     response_builder.body(Body::from(self.body)).unwrap()
   }
 
-  fn set_body(&mut self, body: String) {
-    self.body = body;
+  fn set_body(&mut self, body: Vec<u8>) {
+    self.body = str::from_utf8(&body).unwrap_or("").to_owned();
   }
 }
 

--- a/src/builtins/send.rs
+++ b/src/builtins/send.rs
@@ -7,9 +7,9 @@ use context::Context;
 pub fn file<T: Context>(mut context: T, file_name: &str) -> T {
   let file = File::open(file_name).unwrap();
   let mut buf_reader = BufReader::new(file);
-  let mut contents = String::new();
+  let mut contents = Vec::new();
 
-  buf_reader.read_to_string(&mut contents).unwrap();
+  let _ = buf_reader.read_to_end(&mut contents);
 
   context.set_body(contents);
   context

--- a/src/context.rs
+++ b/src/context.rs
@@ -6,5 +6,5 @@ pub trait Context {
   type Response: Send;
 
   fn get_response(self) -> Self::Response;
-  fn set_body(&mut self, String);
+  fn set_body(&mut self, Vec<u8>);
 }

--- a/src/route_tree/mod.rs
+++ b/src/route_tree/mod.rs
@@ -134,6 +134,7 @@ mod tests {
   use middleware::{Middleware, MiddlewareChain, MiddlewareReturnValue};
   use futures::{future, Future};
   use std::boxed::Box;
+  use smallvec::SmallVec;
 
   #[test]
   fn it_should_match_a_simple_route() {


### PR DESCRIPTION
Currently `set_body` only accepts a `String`, which limits the useability of the api. This moves `set_body` to accepting a `Vec<u8>` which is not limited by utf8 strings.

This resolves [#72] by updating the `builtins::send::file` middleware.