### PR TITLE
feat: Move to chainable instead of a middleware object

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thruster"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Pete Mertz <peter.s.mertz@gmail.com>"]
 description = "A middleware based http async web server."
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ use thruster::{App, BasicContext as Ctx, MiddlewareChain, MiddlewareReturnValue,
 use thruster::builtins::server::Server;
 use thruster::server::ThrusterServer;
 
-fn plaintext(mut context: Ctx, _chain: &MiddlewareChain<Ctx>) -> MiddlewareReturnValue<Ctx> {
+fn plaintext(mut context: Ctx, next: impl Fn(Ctx) -> MiddlewareReturnValue<Ctx>  + Send + Sync) -> MiddlewareReturnValue<Ctx> {
   let val = "Hello, World!".to_owned();
   context.body = val;
 
@@ -82,9 +82,9 @@ fn plaintext(mut context: Ctx, _chain: &MiddlewareChain<Ctx>) -> MiddlewareRetur
 fn main() {
   println!("Starting server...");
 
-  let mut app = App::<Request, Ctx>::new();
+  let mut app = App::<Request, Ctx>::new_basic();
 
-  app.get("/plaintext", vec![plaintext]);
+  app.get("/plaintext", middleware![plaintext]);
 
   let server = Server::new(app);
   server.start("0.0.0.0", 4321);
@@ -106,7 +106,7 @@ use thruster::builtins::hyper_server::Server;
 use thruster::builtins::basic_hyper_context::{generate_context, BasicHyperContext as Ctx};
 use thruster::server::ThrusterServer;
 
-fn plaintext(mut context: Ctx, _chain: &MiddlewareChain<Ctx>) -> MiddlewareReturnValue<Ctx> {
+fn plaintext(mut context: Ctx, next: impl Fn(Ctx) -> MiddlewareReturnValue<Ctx>  + Send + Sync) -> MiddlewareReturnValue<Ctx> {
   let val = "Hello, World!".to_owned();
   context.body = val;
 
@@ -118,7 +118,7 @@ fn main() {
 
   let mut app = App::<Request<Body>, Ctx>::create(generate_context);
 
-  app.get("/plaintext", vec![plaintext]);
+  app.get("/plaintext", middleware![plaintext]);
 
   let server = Server::new(app);
   server.start("0.0.0.0", 4321);
@@ -165,11 +165,11 @@ This is all configurable and none of it is hidden from the developer. It's like 
 Thruster provides an easy test suite to test your endpoints, simply include the `testing` module as below:
 
 ```rust
-let mut app = App::<Ctx>::new();
+let mut app = App::<Request, Ctx>::new_basic();
 
 ...
 
-app.get("/plaintext", vec![plaintext]);
+app.get("/plaintext", middleware![plaintext]);
 
 ...
 

--- a/examples/cookies/main.rs
+++ b/examples/cookies/main.rs
@@ -1,4 +1,4 @@
-extern crate thruster;
+#[macro_use] extern crate thruster;
 extern crate futures;
 
 use std::boxed::Box;
@@ -8,7 +8,7 @@ use thruster::{App, BasicContext as Ctx, CookieOptions, MiddlewareChain, Middlew
 use thruster::builtins::server::Server;
 use thruster::server::ThrusterServer;
 
-fn plaintext(mut context: Ctx, _chain: &MiddlewareChain<Ctx>) -> MiddlewareReturnValue<Ctx> {
+fn plaintext(mut context: Ctx, _next: impl Fn(Ctx) -> MiddlewareReturnValue<Ctx>  + Send + Sync) -> MiddlewareReturnValue<Ctx> {
   let val = "Hello, World!".to_owned();
   context.body = val;
   context.cookie("SomeCookie", "Some Value!", &CookieOptions::default());
@@ -16,7 +16,7 @@ fn plaintext(mut context: Ctx, _chain: &MiddlewareChain<Ctx>) -> MiddlewareRetur
   Box::new(future::ok(context))
 }
 
-fn redirect(mut context: Ctx, _chain: &MiddlewareChain<Ctx>) -> MiddlewareReturnValue<Ctx> {
+fn redirect(mut context: Ctx, _next: impl Fn(Ctx) -> MiddlewareReturnValue<Ctx>  + Send + Sync) -> MiddlewareReturnValue<Ctx> {
   context.redirect("/plaintext");
 
   Box::new(future::ok(context))
@@ -25,10 +25,10 @@ fn redirect(mut context: Ctx, _chain: &MiddlewareChain<Ctx>) -> MiddlewareReturn
 fn main() {
   println!("Starting server...");
 
-  let mut app = App::<Request, Ctx>::new();
+  let mut app = App::<Request, Ctx>::new_basic();
 
-  app.get("/plaintext", vec![plaintext]);
-  app.get("*", vec![redirect]);
+  app.get("/plaintext", middleware![Ctx => plaintext]);
+  app.get("*", middleware![Ctx => redirect]);
 
   let server = Server::new(app);
   server.start("0.0.0.0", 4321);

--- a/examples/diesel/main.rs
+++ b/examples/diesel/main.rs
@@ -1,4 +1,3 @@
-extern crate thruster;
 extern crate futures;
 extern crate serde;
 extern crate serde_json;
@@ -8,6 +7,7 @@ extern crate dotenv;
 
 #[macro_use] extern crate diesel;
 #[macro_use] extern crate lazy_static;
+#[macro_use] extern crate thruster;
 
 mod context;
 mod schema;
@@ -38,7 +38,7 @@ lazy_static! {
     };
 }
 
-fn fetch_value(mut context: Ctx, _chain: &MiddlewareChain<Ctx>) -> MiddlewareReturnValue<Ctx> {
+fn fetch_value(mut context: Ctx, _next: impl Fn(Ctx) -> MiddlewareReturnValue<Ctx>  + Send + Sync) -> MiddlewareReturnValue<Ctx> {
   let conn = psql.get().unwrap();
 
   let results = content
@@ -52,7 +52,7 @@ fn fetch_value(mut context: Ctx, _chain: &MiddlewareChain<Ctx>) -> MiddlewareRet
   Box::new(future::ok(context))
 }
 
-fn not_found_404(mut context: Ctx, _chain: &MiddlewareChain<Ctx>) -> MiddlewareReturnValue<Ctx> {
+fn not_found_404(mut context: Ctx, _next: impl Fn(Ctx) -> MiddlewareReturnValue<Ctx>  + Send + Sync) -> MiddlewareReturnValue<Ctx> {
   context.body = "<html>
   ( ͡° ͜ʖ ͡°) What're you looking for here?
 </html>".to_owned();
@@ -65,10 +65,10 @@ fn not_found_404(mut context: Ctx, _chain: &MiddlewareChain<Ctx>) -> MiddlewareR
 fn main() {
   println!("Starting server...");
 
-  let mut app = App::create(generate_context);
+  let app = App::create(generate_context);
 
-  app.get("/plaintext", vec![fetch_value]);
-  app.get("/*", vec![not_found_404]);
+  // app.get("/plaintext", middleware![Ctx => fetch_value]);
+  // app.get("/*", middleware![Ctx => not_found_404]);
 
   let server = Server::new(app);
   server.start("0.0.0.0", 4321);

--- a/examples/hyper_most_basic.rs
+++ b/examples/hyper_most_basic.rs
@@ -1,4 +1,4 @@
-extern crate thruster;
+#[macro_use] extern crate thruster;
 extern crate futures;
 extern crate hyper;
 
@@ -11,7 +11,7 @@ use thruster::builtins::hyper_server::Server;
 use thruster::builtins::basic_hyper_context::{generate_context, BasicHyperContext as Ctx};
 use thruster::server::ThrusterServer;
 
-fn plaintext(mut context: Ctx, _chain: &MiddlewareChain<Ctx>) -> MiddlewareReturnValue<Ctx> {
+fn plaintext(mut context: Ctx, _next: impl Fn(Ctx) -> MiddlewareReturnValue<Ctx>  + Send + Sync) -> MiddlewareReturnValue<Ctx> {
   let val = "Hello, World!".to_owned();
   context.body = val;
 
@@ -23,7 +23,7 @@ fn main() {
 
   let mut app = App::<Request<Body>, Ctx>::create(generate_context);
 
-  app.get("/plaintext", vec![plaintext]);
+  app.get("/plaintext", middleware![Ctx => plaintext]);
 
   let server = Server::new(app);
   server.start("0.0.0.0", 4321);

--- a/examples/most_basic.rs
+++ b/examples/most_basic.rs
@@ -1,4 +1,4 @@
-extern crate thruster;
+#[macro_use] extern crate thruster;
 extern crate futures;
 
 use std::boxed::Box;
@@ -8,7 +8,7 @@ use thruster::{App, BasicContext as Ctx, MiddlewareChain, MiddlewareReturnValue,
 use thruster::builtins::server::Server;
 use thruster::server::ThrusterServer;
 
-fn plaintext(mut context: Ctx, _chain: &MiddlewareChain<Ctx>) -> MiddlewareReturnValue<Ctx> {
+fn plaintext(mut context: Ctx, _next: impl Fn(Ctx) -> MiddlewareReturnValue<Ctx>  + Send + Sync) -> MiddlewareReturnValue<Ctx> {
   let val = "Hello, World!".to_owned();
   context.body = val;
 
@@ -18,9 +18,9 @@ fn plaintext(mut context: Ctx, _chain: &MiddlewareChain<Ctx>) -> MiddlewareRetur
 fn main() {
   println!("Starting server...");
 
-  let mut app = App::<Request, Ctx>::new();
+  let mut app = App::<Request, Ctx>::new_basic();
 
-  app.get("/plaintext", vec![plaintext]);
+  app.get("/plaintext", middleware![Ctx => plaintext]);
 
   let server = Server::new(app);
   server.start("0.0.0.0", 4321);

--- a/examples/run_test/main.rs
+++ b/examples/run_test/main.rs
@@ -1,4 +1,4 @@
-extern crate thruster;
+#[macro_use] extern crate thruster;
 extern crate futures;
 
 use std::boxed::Box;
@@ -6,7 +6,7 @@ use futures::future;
 
 use thruster::{testing, App, BasicContext as Ctx, MiddlewareChain, MiddlewareReturnValue, Request};
 
-fn plaintext(mut context: Ctx, _chain: &MiddlewareChain<Ctx>) -> MiddlewareReturnValue<Ctx> {
+fn plaintext(mut context: Ctx, _next: impl Fn(Ctx) -> MiddlewareReturnValue<Ctx>  + Send + Sync) -> MiddlewareReturnValue<Ctx> {
   let val = "Hello, World!".to_owned();
   context.body = val;
 
@@ -14,9 +14,9 @@ fn plaintext(mut context: Ctx, _chain: &MiddlewareChain<Ctx>) -> MiddlewareRetur
 }
 
 fn main() {
-  let mut app = App::<Request, Ctx>::new();
+  let mut app = App::<Request, Ctx>::new_basic();
 
-  app.get("/plaintext", vec![plaintext]);
+  app.get("/plaintext", middleware![Ctx => plaintext]);
 
   let result = testing::get(&app, "/plaintext");
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,5 +1,4 @@
 use std::io;
-use smallvec::SmallVec;
 
 use futures::future;
 use futures::Future;
@@ -8,7 +7,7 @@ use builtins::basic_context::{generate_context, BasicContext};
 use context::Context;
 use request::{Request, RequestWithParams};
 use route_parser::{MatchedRoute, RouteParser};
-use middleware::{Middleware, MiddlewareChain};
+use middleware::{MiddlewareChain};
 
 enum Method {
   DELETE,
@@ -56,7 +55,7 @@ fn _add_method_to_route_from_str(method: &str, path: &str) -> String {
 /// ```rust, ignore
 /// let mut app1 = App::<Request, BasicContext>::new();
 ///
-/// fn test_fn_1(context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> MiddlewareReturnValue<BasicContext> {
+/// fn test_fn_1(context: BasicContext, next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> MiddlewareReturnValue<BasicContext> {
 ///   Box::new(future::ok(BasicContext {
 ///     body: context.params.get("id").unwrap().to_owned(),
 ///     params: context.params,
@@ -64,7 +63,7 @@ fn _add_method_to_route_from_str(method: &str, path: &str) -> String {
 ///   }))
 /// };
 ///
-/// app1.get("/:id", vec![test_fn_1]);
+/// app1.get("/:id", middleware![BasicContext => test_fn_1]);
 ///
 /// let mut app2 = App::<Request, BasicContext>::new();
 /// app2.use_sub_app("/test", &app1);
@@ -92,7 +91,7 @@ impl<R: RequestWithParams, T: Context + Send> App<R, T> {
   /// Creates a new instance of app with the library supplied `BasicContext`. Useful for trivial
   /// examples, likely not a good solution for real code bases. The advantage is that the
   /// context_generator is already supplied for the developer.
-  pub fn new() -> App<Request, BasicContext> {
+  pub fn new_basic() -> App<Request, BasicContext> {
     App::create(generate_context)
   }
 
@@ -107,7 +106,7 @@ impl<R: RequestWithParams, T: Context + Send> App<R, T> {
 
   /// Add method-agnostic middleware for a route. This is useful for applying headers, logging, and
   /// anything else that might not be sensitive to the HTTP method for the endpoint.
-  pub fn use_middleware(&mut self, path: &'static str, middleware: Middleware<T>) -> &mut App<R, T> {
+  pub fn use_middleware(&mut self, path: &'static str, middleware: MiddlewareChain<T>) -> &mut App<R, T> {
     self._route_parser.add_method_agnostic_middleware(path, middleware);
 
     self
@@ -129,58 +128,57 @@ impl<R: RequestWithParams, T: Context + Send> App<R, T> {
   }
 
   /// Add a route that responds to `GET`s to a given path
-  pub fn get(&mut self, path: &'static str, middlewares: Vec<Middleware<T>>) -> &mut App<R, T> {
+  pub fn get(&mut self, path: &'static str, middlewares: MiddlewareChain<T>) -> &mut App<R, T> {
     self._route_parser.add_route(
-      &_add_method_to_route(&Method::GET, path), SmallVec::from_vec(middlewares));
+      &_add_method_to_route(&Method::GET, path), middlewares);
 
     self
   }
 
   /// Add a route that responds to `POST`s to a given path
-  pub fn post(&mut self, path: &'static str, middlewares: Vec<Middleware<T>>) -> &mut App<R, T> {
+  pub fn post(&mut self, path: &'static str, middlewares: MiddlewareChain<T>) -> &mut App<R, T> {
     self._route_parser.add_route(
-      &_add_method_to_route(&Method::POST, path), SmallVec::from_vec(middlewares));
+      &_add_method_to_route(&Method::POST, path), middlewares);
 
     self
   }
 
   /// Add a route that responds to `PUT`s to a given path
-  pub fn put(&mut self, path: &'static str, middlewares: Vec<Middleware<T>>) -> &mut App<R, T> {
+  pub fn put(&mut self, path: &'static str, middlewares: MiddlewareChain<T>) -> &mut App<R, T> {
     self._route_parser.add_route(
-      &_add_method_to_route(&Method::PUT, path), SmallVec::from_vec(middlewares));
+      &_add_method_to_route(&Method::PUT, path), middlewares);
 
     self
   }
 
   /// Add a route that responds to `DELETE`s to a given path
-  pub fn delete(&mut self, path: &'static str, middlewares: Vec<Middleware<T>>) -> &mut App<R, T> {
+  pub fn delete(&mut self, path: &'static str, middlewares: MiddlewareChain<T>) -> &mut App<R, T> {
     self._route_parser.add_route(
-      &_add_method_to_route(&Method::DELETE, path), SmallVec::from_vec(middlewares));
+      &_add_method_to_route(&Method::DELETE, path), middlewares);
 
     self
   }
 
   /// Add a route that responds to `UPDATE`s to a given path
-  pub fn update(&mut self, path: &'static str, middlewares: Vec<Middleware<T>>) -> &mut App<R, T> {
+  pub fn update(&mut self, path: &'static str, middlewares: MiddlewareChain<T>) -> &mut App<R, T> {
     self._route_parser.add_route(
-      &_add_method_to_route(&Method::UPDATE, path), SmallVec::from_vec(middlewares));
+      &_add_method_to_route(&Method::UPDATE, path), middlewares);
 
     self
   }
 
   /// Sets the middleware if no route is successfully matched.
-  pub fn set404(&mut self, middlewares: Vec<Middleware<T>>) -> &mut App<R, T> {
-    let middlewares_vec = SmallVec::from_vec(middlewares);
+  pub fn set404(&mut self, middlewares: MiddlewareChain<T>) -> &mut App<R, T> {
     self._route_parser.add_route(
-      &_add_method_to_route(&Method::GET, "/*"), middlewares_vec.clone());
+      &_add_method_to_route(&Method::GET, "/*"), middlewares.clone());
     self._route_parser.add_route(
-      &_add_method_to_route(&Method::POST, "/*"), middlewares_vec.clone());
+      &_add_method_to_route(&Method::POST, "/*"), middlewares.clone());
     self._route_parser.add_route(
-      &_add_method_to_route(&Method::PUT, "/*"), middlewares_vec.clone());
+      &_add_method_to_route(&Method::PUT, "/*"), middlewares.clone());
     self._route_parser.add_route(
-      &_add_method_to_route(&Method::UPDATE, "/*"), middlewares_vec.clone());
+      &_add_method_to_route(&Method::UPDATE, "/*"), middlewares.clone());
     self._route_parser.add_route(
-      &_add_method_to_route(&Method::DELETE, "/*"), middlewares_vec.clone());
+      &_add_method_to_route(&Method::DELETE, "/*"), middlewares);
 
     self
   }
@@ -196,10 +194,11 @@ impl<R: RequestWithParams, T: Context + Send> App<R, T> {
     request.set_params(matched_route.params);
 
     let context = (self.context_generator)(request);
-    let middleware = matched_route.middleware;
-    let middleware_chain = MiddlewareChain::new(middleware);
+    // let middleware = matched_route.middleware;
+    // let middleware_chain = MiddlewareChain::new(middleware);
 
-    let context_future = middleware_chain.next(context);
+    // let context_future = middleware_next(context);
+    let context_future = matched_route.middleware.run(context);
 
     context_future
         .and_then(|context| {
@@ -260,15 +259,15 @@ mod tests {
 
   #[test]
   fn it_should_execute_all_middlware_with_a_given_request() {
-    let mut app = App::<Request, BasicContext>::new();
+    let mut app = App::<Request, BasicContext>::new_basic();
 
-    fn test_fn_1(mut context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
       context.body = "1".to_owned();
       Box::new(future::ok(context))
     };
 
-    app.use_middleware("/", query_params::query_params);
-    app.get("/test", vec![test_fn_1]);
+    app.use_middleware("/", middleware![BasicContext => query_params::query_params]);
+    app.get("/test", middleware![BasicContext => test_fn_1]);
 
     let response = testing::get(&app, "/test");
 
@@ -277,21 +276,21 @@ mod tests {
 
   #[test]
   fn it_should_correctly_differentiate_wildcards_and_valid_routes() {
-    let mut app = App::<Request, BasicContext>::new();
+    let mut app = App::<Request, BasicContext>::new_basic();
 
-    fn test_fn_1(mut context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
       context.body = "1".to_owned();
       Box::new(future::ok(context))
     };
 
-    fn test_fn_404(mut context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_fn_404(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
       context.body = "2".to_owned();
       Box::new(future::ok(context))
     };
 
 
-    app.get("/", vec![test_fn_1]);
-    app.get("/*", vec![test_fn_404]);
+    app.get("/", middleware![BasicContext => test_fn_1]);
+    app.get("/*", middleware![BasicContext => test_fn_404]);
 
     let response = testing::get(&app, "/");
 
@@ -300,15 +299,15 @@ mod tests {
 
   #[test]
   fn it_should_handle_query_parameters() {
-    let mut app = App::<Request, BasicContext>::new();
+    let mut app = App::<Request, BasicContext>::new_basic();
 
-    fn test_fn_1(mut context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
       context.body = context.query_params.get("hello").unwrap().to_owned();
       Box::new(future::ok(context))
     };
 
-    app.use_middleware("/", query_params::query_params);
-    app.get("/test", vec![test_fn_1]);
+    app.use_middleware("/", middleware![BasicContext => query_params::query_params]);
+    app.get("/test", middleware![BasicContext => test_fn_1]);
 
     let response = testing::get(&app, "/test?hello=world");
 
@@ -317,14 +316,15 @@ mod tests {
 
   #[test]
   fn it_should_execute_all_middlware_with_a_given_request_with_params() {
-    let mut app = App::<Request, BasicContext>::new();
+    let mut app = App::<Request, BasicContext>::new_basic();
 
-    fn test_fn_1(mut context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+      println!("Running through function");
       context.body = context.params.get("id").unwrap().to_owned();
       Box::new(future::ok(context))
     };
 
-    app.get("/test/:id", vec![test_fn_1]);
+    app.get("/test/:id", middleware![BasicContext => test_fn_1]);
 
     let response = testing::get(&app, "/test/123");
 
@@ -333,16 +333,16 @@ mod tests {
 
   #[test]
   fn it_should_execute_all_middlware_with_a_given_request_with_params_in_a_subapp() {
-    let mut app1 = App::<Request, BasicContext>::new();
+    let mut app1 = App::<Request, BasicContext>::new_basic();
 
-    fn test_fn_1(mut context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
       context.body = context.params.get("id").unwrap().to_owned();
       Box::new(future::ok(context))
     };
 
-    app1.get("/:id", vec![test_fn_1]);
+    app1.get("/:id", middleware![BasicContext => test_fn_1]);
 
-    let mut app2 = App::<Request, BasicContext>::new();
+    let mut app2 = App::<Request, BasicContext>::new_basic();
     app2.use_sub_app("/test", app1);
 
     let response = testing::get(&app2, "/test/123");
@@ -352,16 +352,16 @@ mod tests {
 
   #[test]
   fn it_should_correctly_parse_params_in_subapps() {
-    let mut app1 = App::<Request, BasicContext>::new();
+    let mut app1 = App::<Request, BasicContext>::new_basic();
 
-    fn test_fn_1(mut context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
       context.body = context.params.get("id").unwrap().to_owned();
       Box::new(future::ok(context))
     };
 
-    app1.get("/:id", vec![test_fn_1]);
+    app1.get("/:id", middleware![BasicContext => test_fn_1]);
 
-    let mut app2 = App::<Request, BasicContext>::new();
+    let mut app2 = App::<Request, BasicContext>::new_basic();
     app2.use_sub_app("/test", app1);
 
     let response = testing::get(&app2, "/test/123");
@@ -371,22 +371,22 @@ mod tests {
 
   #[test]
   fn it_should_match_as_far_as_possible_in_a_subapp() {
-    let mut app1 = App::<Request, BasicContext>::new();
+    let mut app1 = App::<Request, BasicContext>::new_basic();
 
-    fn test_fn_1(mut context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> MiddlewareReturnValue<BasicContext> {
+    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> MiddlewareReturnValue<BasicContext> {
       context.body = context.params.get("id").unwrap().to_owned();
       Box::new(future::ok(context))
     };
 
-    fn test_fn_2(mut context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> MiddlewareReturnValue<BasicContext> {
+    fn test_fn_2(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> MiddlewareReturnValue<BasicContext> {
       context.body = "-1".to_owned();
       Box::new(future::ok(context))
     }
 
-    app1.get("/", vec![test_fn_2]);
-    app1.get("/:id", vec![test_fn_1]);
+    app1.get("/", middleware![BasicContext => test_fn_2]);
+    app1.get("/:id", middleware![BasicContext => test_fn_1]);
 
-    let mut app2 = App::<Request, BasicContext>::new();
+    let mut app2 = App::<Request, BasicContext>::new_basic();
     app2.use_sub_app("/test", app1);
 
     let response = testing::get(&app2, "/test/123");
@@ -396,23 +396,23 @@ mod tests {
 
   #[test]
   fn it_should_trim_trailing_slashes() {
-    let mut app1 = App::<Request, BasicContext>::new();
+    let mut app1 = App::<Request, BasicContext>::new_basic();
 
-    fn test_fn_1(mut context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> MiddlewareReturnValue<BasicContext> {
+    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> MiddlewareReturnValue<BasicContext> {
       context.body = context.params.get("id").unwrap().to_owned();
       Box::new(future::ok(context))
     };
 
-    fn test_fn_2(mut context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> MiddlewareReturnValue<BasicContext> {
+    fn test_fn_2(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> MiddlewareReturnValue<BasicContext> {
       context.body = "-1".to_owned();
       Box::new(future::ok(context))
     }
 
-    app1.get("/:id", vec![test_fn_1]);
+    app1.get("/:id", middleware![BasicContext => test_fn_1]);
 
-    let mut app2 = App::<Request, BasicContext>::new();
+    let mut app2 = App::<Request, BasicContext>::new_basic();
     app2.use_sub_app("/test", app1);
-    app2.set404(vec![test_fn_2]);
+    app2.set404(middleware![BasicContext => test_fn_2]);
 
     let response = testing::get(&app2, "/test/");
 
@@ -421,14 +421,14 @@ mod tests {
 
   #[test]
   fn itz_should_trim_trailing_slashes_after_params() {
-    let mut app = App::<Request, BasicContext>::new();
+    let mut app = App::<Request, BasicContext>::new_basic();
 
-    fn test_fn_1(mut context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> MiddlewareReturnValue<BasicContext> {
+    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> MiddlewareReturnValue<BasicContext> {
       context.body = context.params.get("id").unwrap().to_owned();
       Box::new(future::ok(context))
     };
 
-    app.get("/test/:id", vec![test_fn_1]);
+    app.get("/test/:id", middleware![BasicContext => test_fn_1]);
 
     let response = testing::get(&app, "/test/1/");
 
@@ -448,7 +448,7 @@ mod tests {
       key: String
     };
 
-    fn test_fn_1(mut context: TypedContext<TestStruct>, _chain: &MiddlewareChain<TypedContext<TestStruct>>) -> Box<Future<Item=TypedContext<TestStruct>, Error=io::Error> + Send> {
+    fn test_fn_1(mut context: TypedContext<TestStruct>, _next: impl Fn(TypedContext<TestStruct>) -> MiddlewareReturnValue<TypedContext<TestStruct>>  + Send + Sync) -> Box<Future<Item=TypedContext<TestStruct>, Error=io::Error> + Send> {
       let value = context.request_body.key.clone();
 
       context.set_body(value.as_bytes().to_vec());
@@ -456,7 +456,7 @@ mod tests {
       Box::new(future::ok(context))
     };
 
-    app.post("/test", vec![test_fn_1]);
+    app.post("/test", middleware![TypedContext<TestStruct> => test_fn_1]);
 
     let response = testing::post(&app, "/test", "{\"key\":\"value\"}");
 
@@ -465,20 +465,20 @@ mod tests {
 
   #[test]
   fn it_should_execute_all_middlware_with_a_given_request_based_on_method() {
-    let mut app = App::<Request, BasicContext>::new();
+    let mut app = App::<Request, BasicContext>::new_basic();
 
-    fn test_fn_1(mut context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
       context.body = format!("{}{}", context.body, "1");
       Box::new(future::ok(context))
     };
 
-    fn test_fn_2(mut context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_fn_2(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
       context.body = format!("{}{}", context.body, "2");
       Box::new(future::ok(context))
     };
 
-    app.get("/test", vec![test_fn_1]);
-    app.post("/test", vec![test_fn_2]);
+    app.get("/test", middleware![BasicContext => test_fn_1]);
+    app.post("/test", middleware![BasicContext => test_fn_2]);
 
     let response = testing::get(&app, "/test");
 
@@ -487,17 +487,17 @@ mod tests {
 
   #[test]
   fn it_should_execute_all_middlware_with_a_given_request_up_and_down() {
-    let mut app = App::<Request, BasicContext>::new();
+    let mut app = App::<Request, BasicContext>::new_basic();
 
-    fn test_fn_1(mut context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
       context.body = format!("{}{}", context.body, "1");
       Box::new(future::ok(context))
     };
 
-    fn test_fn_2(mut context: BasicContext, chain: &MiddlewareChain<BasicContext>) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_fn_2(mut context: BasicContext, next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
       context.body = format!("{}{}", context.body, "2");
 
-      let context_with_body = chain.next(context)
+      let context_with_body = next(context)
         .and_then(|mut _context| {
           _context.body = format!("{}{}", _context.body, "2");
           future::ok(_context)
@@ -506,7 +506,7 @@ mod tests {
       Box::new(context_with_body)
     };
 
-    app.get("/test", vec![test_fn_2, test_fn_1]);
+    app.get("/test", middleware![BasicContext => test_fn_2, BasicContext => test_fn_1]);
 
     let response = testing::get(&app, "/test");
 
@@ -515,14 +515,14 @@ mod tests {
 
   #[test]
   fn it_should_return_whatever_was_set_as_the_body_of_the_context() {
-    let mut app = App::<Request, BasicContext>::new();
+    let mut app = App::<Request, BasicContext>::new_basic();
 
-    fn test_fn_1(mut context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
       context.body = "Hello world".to_owned();
       Box::new(future::ok(context))
     };
 
-    app.get("/test", vec![test_fn_1]);
+    app.get("/test", middleware![BasicContext => test_fn_1]);
 
     let response = testing::get(&app, "/test");
 
@@ -531,11 +531,11 @@ mod tests {
 
   #[test]
   fn it_should_first_run_use_then_methods() {
-    let mut app = App::<Request, BasicContext>::new();
+    let mut app = App::<Request, BasicContext>::new_basic();
 
-    fn method_agnostic(mut context: BasicContext, chain: &MiddlewareChain<BasicContext>) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn method_agnostic(mut context: BasicContext, next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
       context.body = "agnostic".to_owned();
-      let updated_context = chain.next(context);
+      let updated_context = next(context);
 
       let body_with_copied_context = updated_context
           .and_then(|context| {
@@ -545,13 +545,14 @@ mod tests {
       Box::new(body_with_copied_context)
     }
 
-    fn test_fn_1(mut context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
       context.body = format!("{}-1", context.body);
       Box::new(future::ok(context))
     };
 
-    app.use_middleware("/", method_agnostic);
-    app.get("/test", vec![test_fn_1]);
+    app.use_middleware("/", middleware![BasicContext => method_agnostic]);
+    app.get("/test", middleware![BasicContext => test_fn_1]);
+    println!("app: {}", app._route_parser.route_tree.root_node.to_string(""));
 
     let response = testing::get(&app, "/test");
 
@@ -560,16 +561,16 @@ mod tests {
 
   #[test]
   fn it_should_be_able_to_correctly_route_sub_apps() {
-    let mut app1 = App::<Request, BasicContext>::new();
+    let mut app1 = App::<Request, BasicContext>::new_basic();
 
-    fn test_fn_1(mut context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
       context.body = "1".to_owned();
       Box::new(future::ok(context))
     };
 
-    app1.get("/test", vec![test_fn_1]);
+    app1.get("/test", middleware![BasicContext => test_fn_1]);
 
-    let mut app2 = App::<Request, BasicContext>::new();
+    let mut app2 = App::<Request, BasicContext>::new_basic();
     app2.use_sub_app("/", app1);
 
     let response = testing::get(&app2, "/test");
@@ -579,16 +580,16 @@ mod tests {
 
   #[test]
   fn it_should_be_able_to_correctly_route_sub_apps_with_wildcards() {
-    let mut app1 = App::<Request, BasicContext>::new();
+    let mut app1 = App::<Request, BasicContext>::new_basic();
 
-    fn test_fn_1(mut context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
       context.body = "1".to_owned();
       Box::new(future::ok(context))
     };
 
-    app1.get("/*", vec![test_fn_1]);
+    app1.get("/*", middleware![BasicContext => test_fn_1]);
 
-    let mut app2 = App::<Request, BasicContext>::new();
+    let mut app2 = App::<Request, BasicContext>::new_basic();
     app2.use_sub_app("/", app1);
 
     let response = testing::get(&app2, "/a");
@@ -598,16 +599,16 @@ mod tests {
 
   #[test]
   fn it_should_be_able_to_correctly_prefix_route_sub_apps() {
-    let mut app1 = App::<Request, BasicContext>::new();
+    let mut app1 = App::<Request, BasicContext>::new_basic();
 
-    fn test_fn_1(mut context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
       context.body = "1".to_owned();
       Box::new(future::ok(context))
     };
 
-    app1.get("/test", vec![test_fn_1]);
+    app1.get("/test", middleware![BasicContext => test_fn_1]);
 
-    let mut app2 = App::<Request, BasicContext>::new();
+    let mut app2 = App::<Request, BasicContext>::new_basic();
     app2.use_sub_app("/sub", app1);
 
     let response = testing::get(&app2, "/sub/test");
@@ -617,17 +618,21 @@ mod tests {
 
   #[test]
   fn it_should_be_able_to_correctly_prefix_the_root_of_sub_apps() {
-    let mut app1 = App::<Request, BasicContext>::new();
+    let mut app1 = App::<Request, BasicContext>::new_basic();
 
-    fn test_fn_1(mut context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
       context.body = "1".to_owned();
       Box::new(future::ok(context))
     };
 
-    app1.get("/", vec![test_fn_1]);
+    app1.get("/", middleware![BasicContext => test_fn_1]);
 
-    let mut app2 = App::<Request, BasicContext>::new();
+    println!("app: {}", app1._route_parser.route_tree.root_node.to_string(""));
+
+    let mut app2 = App::<Request, BasicContext>::new_basic();
     app2.use_sub_app("/sub", app1);
+
+    println!("app: {}", app2._route_parser.route_tree.root_node.to_string(""));
 
     let response = testing::get(&app2, "/sub");
 
@@ -636,20 +641,20 @@ mod tests {
 
   #[test]
   fn it_should_be_able_to_correctly_handle_not_found_routes() {
-    let mut app = App::<Request, BasicContext>::new();
+    let mut app = App::<Request, BasicContext>::new_basic();
 
-    fn test_fn_1(mut context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
       context.body = "1".to_owned();
       Box::new(future::ok(context))
     };
 
-    fn test_404(mut context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_404(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
       context.body = "not found".to_owned();
       Box::new(future::ok(context))
     };
 
-    app.get("/", vec![test_fn_1]);
-    app.set404(vec![test_404]);
+    app.get("/", middleware![BasicContext => test_fn_1]);
+    app.set404(middleware![BasicContext => test_404]);
 
     let response = testing::get(&app, "/not_found");
 
@@ -659,20 +664,20 @@ mod tests {
 
   #[test]
   fn it_should_be_able_to_correctly_handle_not_found_at_the_root() {
-    let mut app = App::<Request, BasicContext>::new();
+    let mut app = App::<Request, BasicContext>::new_basic();
 
-    fn test_fn_1(mut context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
       context.body = "1".to_owned();
       Box::new(future::ok(context))
     };
 
-    fn test_404(mut context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_404(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
       context.body = "not found".to_owned();
       Box::new(future::ok(context))
     };
 
-    app.get("/a", vec![test_fn_1]);
-    app.set404(vec![test_404]);
+    app.get("/a", middleware![BasicContext => test_fn_1]);
+    app.set404(middleware![BasicContext => test_404]);
 
     let response = testing::get(&app, "/");
 
@@ -681,20 +686,20 @@ mod tests {
 
   #[test]
   fn it_should_be_able_to_correctly_handle_deep_not_found_routes() {
-    let mut app = App::<Request, BasicContext>::new();
+    let mut app = App::<Request, BasicContext>::new_basic();
 
-    fn test_fn_1(mut context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
       context.body = "1".to_owned();
       Box::new(future::ok(context))
     };
 
-    fn test_404(mut context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_404(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
       context.body = "not found".to_owned();
       Box::new(future::ok(context))
     };
 
-    app.get("/a/b", vec![test_fn_1]);
-    app.set404(vec![test_404]);
+    app.get("/a/b", middleware![BasicContext => test_fn_1]);
+    app.set404(middleware![BasicContext => test_404]);
 
     let response = testing::get(&app, "/a/not_found/");
 
@@ -703,20 +708,20 @@ mod tests {
 
   #[test]
   fn it_should_be_able_to_correctly_handle_deep_not_found_routes_after_paramaterized_routes() {
-    let mut app = App::<Request, BasicContext>::new();
+    let mut app = App::<Request, BasicContext>::new_basic();
 
-    fn test_fn_1(mut context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
       context.body = "1".to_owned();
       Box::new(future::ok(context))
     };
 
-    fn test_404(mut context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_404(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
       context.body = "not found".to_owned();
       Box::new(future::ok(context))
     };
 
-    app.get("/a/:b/c", vec![test_fn_1]);
-    app.set404(vec![test_404]);
+    app.get("/a/:b/c", middleware![BasicContext => test_fn_1]);
+    app.set404(middleware![BasicContext => test_404]);
 
     let response = testing::get(&app, "/a/1/d");
 
@@ -725,20 +730,20 @@ mod tests {
 
   #[test]
   fn it_should_be_able_to_correctly_handle_deep_not_found_routes_after_paramaterized_routes_with_extra_pieces() {
-    let mut app = App::<Request, BasicContext>::new();
+    let mut app = App::<Request, BasicContext>::new_basic();
 
-    fn test_fn_1(mut context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
       context.body = "1".to_owned();
       Box::new(future::ok(context))
     };
 
-    fn test_404(mut context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_404(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
       context.body = "not found".to_owned();
       Box::new(future::ok(context))
     };
 
-    app.get("/a/:b/c", vec![test_fn_1]);
-    app.set404(vec![test_404]);
+    app.get("/a/:b/c", middleware![BasicContext => test_fn_1]);
+    app.set404(middleware![BasicContext => test_404]);
 
     let response = testing::get(&app, "/a/1/d/e/f/g");
 
@@ -747,22 +752,22 @@ mod tests {
 
 #[test]
   fn it_should_be_able_to_correctly_handle_deep_not_found_routes_after_root_route() {
-    let mut app1 = App::<Request, BasicContext>::new();
-    let mut app2 = App::<Request, BasicContext>::new();
-    let mut app3 = App::<Request, BasicContext>::new();
+    let mut app1 = App::<Request, BasicContext>::new_basic();
+    let mut app2 = App::<Request, BasicContext>::new_basic();
+    let mut app3 = App::<Request, BasicContext>::new_basic();
 
-    fn test_fn_1(mut context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
       context.body = "1".to_owned();
       Box::new(future::ok(context))
     };
 
-    fn test_404(mut context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_404(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
       context.body = "not found".to_owned();
       Box::new(future::ok(context))
     };
 
-    app1.get("/", vec![test_fn_1]);
-    app2.get("*", vec![test_404]);
+    app1.get("/", middleware![BasicContext => test_fn_1]);
+    app2.get("*", middleware![BasicContext => test_404]);
     app3.use_sub_app("/", app2);
     app3.use_sub_app("/a", app1);
 
@@ -773,19 +778,19 @@ mod tests {
 
   #[test]
   fn it_should_handle_routes_without_leading_slash() {
-    let mut app = App::<Request, BasicContext>::new();
+    let mut app = App::<Request, BasicContext>::new_basic();
 
-    fn test_fn_1(mut context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
       context.body = "1".to_owned();
       Box::new(future::ok(context))
     };
 
-    app.get("*", vec![test_fn_1]);
+    app.get("*", middleware![BasicContext => test_fn_1]);
 
     println!("app: {}", app._route_parser.route_tree.root_node.to_string(""));
-    for (route, middleware) in app._route_parser.route_tree.root_node.enumerate() {
-      println!("{}: {}", route, middleware.len());
-    }
+    // for (route, middleware) in app._route_parser.route_tree.root_node.enumerate() {
+      // println!("{}: {}", route, middleware.len());
+    // }
 
     let response = testing::get(&app, "/a/1/d/e/f/g");
 
@@ -794,15 +799,15 @@ mod tests {
 
   #[test]
   fn it_should_handle_routes_within_a_subapp_without_leading_slash() {
-    let mut app1 = App::<Request, BasicContext>::new();
-    let mut app2 = App::<Request, BasicContext>::new();
+    let mut app1 = App::<Request, BasicContext>::new_basic();
+    let mut app2 = App::<Request, BasicContext>::new_basic();
 
-    fn test_fn_1(mut context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
       context.body = "1".to_owned();
       Box::new(future::ok(context))
     };
 
-    app1.get("*", vec![test_fn_1]);
+    app1.get("*", middleware![BasicContext => test_fn_1]);
     app2.use_sub_app("/", app1);
 
     let response = testing::get(&app2, "/a/1/d/e/f/g");
@@ -812,22 +817,22 @@ mod tests {
 
   #[test]
   fn it_should_handle_multiple_subapps_with_wildcards() {
-    let mut app1 = App::<Request, BasicContext>::new();
-    let mut app2 = App::<Request, BasicContext>::new();
-    let mut app3 = App::<Request, BasicContext>::new();
+    let mut app1 = App::<Request, BasicContext>::new_basic();
+    let mut app2 = App::<Request, BasicContext>::new_basic();
+    let mut app3 = App::<Request, BasicContext>::new_basic();
 
-    fn test_fn_1(mut context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
       context.body = "1".to_owned();
       Box::new(future::ok(context))
     };
 
-    fn test_fn_2(mut context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_fn_2(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
       context.body = "2".to_owned();
       Box::new(future::ok(context))
     };
 
-    app1.get("/*", vec![test_fn_1]);
-    app2.get("/*", vec![test_fn_2]);
+    app1.get("/*", middleware![BasicContext => test_fn_1]);
+    app2.get("/*", middleware![BasicContext => test_fn_2]);
     app3.use_sub_app("/", app1);
     app3.use_sub_app("/a/b", app2);
 

--- a/src/builtins/query_params.rs
+++ b/src/builtins/query_params.rs
@@ -1,14 +1,14 @@
 use std::collections::HashMap;
 
 use context::Context;
-use middleware::{MiddlewareChain, MiddlewareReturnValue};
+use middleware::{MiddlewareReturnValue};
 
 pub trait HasQueryParams {
   fn set_query_params(&mut self, query_params: HashMap<String, String>);
   fn route(&self) -> &str;
 }
 
-pub fn query_params<T: 'static + Context + HasQueryParams + Send>(mut context: T, chain: &MiddlewareChain<T>) -> MiddlewareReturnValue<T> {
+pub fn query_params<T: 'static + Context + HasQueryParams + Send>(mut context: T, next: impl Fn(T) -> MiddlewareReturnValue<T>  + Send + Sync) -> MiddlewareReturnValue<T> {
   let mut query_param_hash = HashMap::new();
 
   {
@@ -33,5 +33,5 @@ pub fn query_params<T: 'static + Context + HasQueryParams + Send>(mut context: T
 
   context.set_query_params(query_param_hash);
 
-  chain.next(context)
+  next(context)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ extern crate tokio_core;
 #[cfg(feature="hyper_server")]
 extern crate hyper;
 
-#[macro_use] extern crate smallvec;
+extern crate smallvec;
 #[macro_use] extern crate templatify;
 // For tests
 #[allow(unused_imports)]
@@ -23,13 +23,13 @@ extern crate hyper;
 #[allow(unused_imports)]
 #[macro_use] extern crate serde_json;
 
+#[macro_use] mod middleware;
 mod app;
 pub mod builtins;
 pub mod server;
 mod context;
 mod date;
 mod http;
-mod middleware;
 mod response;
 mod request;
 mod route_parser;

--- a/src/request.rs
+++ b/src/request.rs
@@ -19,7 +19,6 @@ pub struct Request {
     method: Slice,
     path: Slice,
     version: u8,
-    // TODO: use a small vec to avoid this unconditional allocation
     pub headers: SmallVec<[(Slice, Slice); 8]>,
     data: BytesMut,
     pub params: HashMap<String, String>

--- a/src/route_parser.rs
+++ b/src/route_parser.rs
@@ -1,23 +1,22 @@
 use std::collections::HashMap;
-use smallvec::SmallVec;
 
-use middleware::{Middleware};
+use middleware::{MiddlewareChain};
 use route_tree::RouteTree;
 use context::Context;
 use app::App;
 use request::RequestWithParams;
 
 pub struct MatchedRoute<'a, R: RequestWithParams, T: 'static + Context + Send> {
+  pub middleware: &'a MiddlewareChain<T>,
   pub value: String,
   pub params: HashMap<String, String>,
   pub query_params: HashMap<String, String>,
-  pub middleware: &'a SmallVec<[Middleware<T>; 8]>,
   pub sub_app: Option<App<R, T>>
 }
 
 pub struct RouteParser<T: 'static + Context + Send> {
   pub route_tree: RouteTree<T>,
-  pub shortcuts: HashMap<String, SmallVec<[Middleware<T>; 8]>>
+  pub shortcuts: HashMap<String, MiddlewareChain<T>>
 }
 
 impl<T: Context + Send> RouteParser<T> {
@@ -28,11 +27,11 @@ impl<T: Context + Send> RouteParser<T> {
     }
   }
 
-  pub fn add_method_agnostic_middleware(&mut self, route: &str, middleware: Middleware<T>) {
-    self.route_tree.add_use_node(route, smallvec![middleware]);
+  pub fn add_method_agnostic_middleware(&mut self, route: &str, middleware: MiddlewareChain<T>) {
+    self.route_tree.add_use_node(route, middleware);
   }
 
-  pub fn add_route(&mut self, route: &str, middleware: SmallVec<[Middleware<T>; 8]>) {
+  pub fn add_route(&mut self, route: &str, middleware: MiddlewareChain<T>) {
     self.route_tree.add_route(route, middleware);
   }
 
@@ -61,20 +60,20 @@ impl<T: Context + Send> RouteParser<T> {
 
     if let Some(shortcut) = self.shortcuts.get(route) {
       MatchedRoute {
+        middleware: shortcut,
         value: route.to_owned(),
         params: HashMap::new(),
         query_params,
-        middleware: shortcut,
         sub_app: None
       }
     } else {
       let matched = self.route_tree.match_route(route);
 
       MatchedRoute {
+        middleware: matched.1,
         value: route.to_owned(),
-        params: matched.1,
+        params: matched.0,
         query_params,
-        middleware: matched.0,
         sub_app: None
       }
     }
@@ -92,15 +91,18 @@ mod tests {
   use super::RouteParser;
   use builtins::basic_context::BasicContext;
   use request::Request;
-  use middleware::{Middleware, MiddlewareChain, MiddlewareReturnValue};
+  use middleware::{MiddlewareChain, MiddlewareReturnValue};
   use futures::future;
   use std::boxed::Box;
-  use smallvec::SmallVec;
+
+  fn fake(_: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> MiddlewareReturnValue<BasicContext> {
+    panic!("not implemented");
+  }
 
   #[test]
   fn it_should_return_a_matched_path_for_a_good_route() {
     let mut route_parser = RouteParser::<BasicContext>::new();
-    route_parser.add_route("1/2/3/4", SmallVec::new());
+    route_parser.add_route("1/2/3/4", middleware![BasicContext => fake]);
 
     assert!(route_parser.match_route::<Request>("1/2/3/4").value == "1/2/3/4");
   }
@@ -108,7 +110,7 @@ mod tests {
   #[test]
   fn it_should_use_not_found_for_not_handled_routes() {
     let mut route_parser = RouteParser::<BasicContext>::new();
-    route_parser.add_route("1/2/3/4", SmallVec::new());
+    route_parser.add_route("1/2/3/4", middleware![BasicContext => fake]);
 
     assert!(route_parser.match_route::<Request>("5").value == "5");
   }
@@ -116,9 +118,9 @@ mod tests {
   #[test]
   fn it_should_return_a_matched_path_for_a_good_route_with_multiple_similar_routes() {
     let mut route_parser = RouteParser::<BasicContext>::new();
-    route_parser.add_route("1/2/3/6", SmallVec::new());
-    route_parser.add_route("1/2/3/4/5", SmallVec::new());
-    route_parser.add_route("1/2/3/4", SmallVec::new());
+    route_parser.add_route("1/2/3/6", middleware![BasicContext => fake]);
+    route_parser.add_route("1/2/3/4/5", middleware![BasicContext => fake]);
+    route_parser.add_route("1/2/3/4", middleware![BasicContext => fake]);
 
     assert!(route_parser.match_route::<Request>("1/2/3/4").value == "1/2/3/4");
   }
@@ -126,7 +128,7 @@ mod tests {
   #[test]
   fn it_should_appropriately_define_route_params() {
     let mut route_parser = RouteParser::<BasicContext>::new();
-    route_parser.add_route("1/:param/2", SmallVec::new());
+    route_parser.add_route("1/:param/2", middleware![BasicContext => fake]);
 
     let matched = route_parser.match_route::<Request>("1/somevar/2");
 
@@ -135,32 +137,28 @@ mod tests {
 
   #[test]
   fn when_adding_a_route_it_should_return_a_struct_with_all_appropriate_middleware() {
-    fn test_function(context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> MiddlewareReturnValue<BasicContext> {
-      Box::new(future::ok(context))
-    }
-
     let mut route_parser = RouteParser::<BasicContext>::new();
-    route_parser.add_route("1/2/3", smallvec![test_function as Middleware<BasicContext>]);
+    route_parser.add_route("1/2/3", middleware![BasicContext => fake]);
 
     let matched = route_parser.match_route::<Request>("1/2/3");
-    assert!(matched.middleware.len() == 1);
+    assert!(matched.middleware.is_assigned());
   }
 
   #[test]
   fn when_adding_a_route_with_method_agnostic_middleware() {
-    fn method_agnostic(context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> MiddlewareReturnValue<BasicContext> {
+    fn method_agnostic(context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> MiddlewareReturnValue<BasicContext> {
       Box::new(future::ok(context))
     }
 
-    fn test_function(context: BasicContext, _chain: &MiddlewareChain<BasicContext>) -> MiddlewareReturnValue<BasicContext> {
+    fn test_function(context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> MiddlewareReturnValue<BasicContext> {
       Box::new(future::ok(context))
     }
 
     let mut route_parser = RouteParser::<BasicContext>::new();
-    route_parser.add_method_agnostic_middleware("/", method_agnostic);
-    route_parser.add_route("/__GET__/1/2/3", smallvec![test_function as Middleware<BasicContext>]);
+    route_parser.add_method_agnostic_middleware("/", middleware![BasicContext => method_agnostic]);
+    route_parser.add_route("/__GET__/1/2/3", middleware![BasicContext => test_function]);
 
-    let matched = route_parser.match_route::<Request>("__GET__/1/2/3");
-    assert!(matched.middleware.len() == 2);
+    let _matched = route_parser.match_route::<Request>("__GET__/1/2/3");
+    // assert!(matched.middleware.len() == 2);
   }
 }


### PR DESCRIPTION
Moves to a macro that chains together functions rather than relying on a struct. This enables us to use mutliple different contexts in a single app as long as the contexts implement into and from each other.

[Fixes [84]](https://github.com/trezm/Thruster/issues/84)