### PR TITLE
feat: Do not cast body to utf8 string in BasicContext

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thruster"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Pete Mertz <peter.s.mertz@gmail.com>"]
 description = "A middleware based http async web server."
 readme = "README.md"

--- a/examples/cookies/main.rs
+++ b/examples/cookies/main.rs
@@ -9,8 +9,8 @@ use thruster::builtins::server::Server;
 use thruster::server::ThrusterServer;
 
 fn plaintext(mut context: Ctx, _next: impl Fn(Ctx) -> MiddlewareReturnValue<Ctx>  + Send + Sync) -> MiddlewareReturnValue<Ctx> {
-  let val = "Hello, World!".to_owned();
-  context.body = val;
+  let val = "Hello, World!";
+  context.body(val);
   context.cookie("SomeCookie", "Some Value!", &CookieOptions::default());
 
   Box::new(future::ok(context))

--- a/examples/most_basic.rs
+++ b/examples/most_basic.rs
@@ -9,8 +9,8 @@ use thruster::builtins::server::Server;
 use thruster::server::ThrusterServer;
 
 fn plaintext(mut context: Ctx, _next: impl Fn(Ctx) -> MiddlewareReturnValue<Ctx>  + Send + Sync) -> MiddlewareReturnValue<Ctx> {
-  let val = "Hello, World!".to_owned();
-  context.body = val;
+  let val = "Hello, World!";
+  context.body(val);
 
   Box::new(future::ok(context))
 }

--- a/examples/multicontext.rs
+++ b/examples/multicontext.rs
@@ -42,7 +42,7 @@ impl Context for Ctx {
 impl From<BasicContext> for Ctx {
   fn from(basic: BasicContext) -> Ctx {
     Ctx {
-      body: basic.body
+      body: basic.get_body()
     }
   }
 }
@@ -51,7 +51,7 @@ impl Into<BasicContext> for Ctx {
   fn into(self: Self) -> BasicContext {
     let mut b = BasicContext::new();
 
-    b.body = self.body;
+    b.body(&self.body);
 
     b
   }

--- a/examples/run_test/main.rs
+++ b/examples/run_test/main.rs
@@ -7,8 +7,8 @@ use futures::future;
 use thruster::{testing, App, BasicContext as Ctx, MiddlewareChain, MiddlewareReturnValue, Request};
 
 fn plaintext(mut context: Ctx, _next: impl Fn(Ctx) -> MiddlewareReturnValue<Ctx>  + Send + Sync) -> MiddlewareReturnValue<Ctx> {
-  let val = "Hello, World!".to_owned();
-  context.body = val;
+  let val = "Hello, World!";
+  context.body(val);
 
   Box::new(future::ok(context))
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -262,7 +262,7 @@ mod tests {
     let mut app = App::<Request, BasicContext>::new_basic();
 
     fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
-      context.body = "1".to_owned();
+      context.body("1");
       Box::new(future::ok(context))
     };
 
@@ -279,12 +279,12 @@ mod tests {
     let mut app = App::<Request, BasicContext>::new_basic();
 
     fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
-      context.body = "1".to_owned();
+      context.body("1");
       Box::new(future::ok(context))
     };
 
     fn test_fn_404(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
-      context.body = "2".to_owned();
+      context.body("2");
       Box::new(future::ok(context))
     };
 
@@ -302,7 +302,9 @@ mod tests {
     let mut app = App::<Request, BasicContext>::new_basic();
 
     fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
-      context.body = context.query_params.get("hello").unwrap().to_owned();
+      let body = &context.query_params.get("hello").unwrap().clone();
+
+      context.body(body);
       Box::new(future::ok(context))
     };
 
@@ -319,8 +321,9 @@ mod tests {
     let mut app = App::<Request, BasicContext>::new_basic();
 
     fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
-      println!("Running through function");
-      context.body = context.params.get("id").unwrap().to_owned();
+      let body = &context.params.get("id").unwrap().clone();
+
+      context.body(body);
       Box::new(future::ok(context))
     };
 
@@ -336,7 +339,9 @@ mod tests {
     let mut app1 = App::<Request, BasicContext>::new_basic();
 
     fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
-      context.body = context.params.get("id").unwrap().to_owned();
+      let body = &context.params.get("id").unwrap().clone();
+
+      context.body(body);
       Box::new(future::ok(context))
     };
 
@@ -355,7 +360,9 @@ mod tests {
     let mut app1 = App::<Request, BasicContext>::new_basic();
 
     fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
-      context.body = context.params.get("id").unwrap().to_owned();
+      let body = &context.params.get("id").unwrap().clone();
+
+      context.body(body);
       Box::new(future::ok(context))
     };
 
@@ -374,12 +381,14 @@ mod tests {
     let mut app1 = App::<Request, BasicContext>::new_basic();
 
     fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> MiddlewareReturnValue<BasicContext> {
-      context.body = context.params.get("id").unwrap().to_owned();
+      let body = &context.params.get("id").unwrap().clone();
+
+      context.body(body);
       Box::new(future::ok(context))
     };
 
     fn test_fn_2(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> MiddlewareReturnValue<BasicContext> {
-      context.body = "-1".to_owned();
+      context.body("-1");
       Box::new(future::ok(context))
     }
 
@@ -399,12 +408,14 @@ mod tests {
     let mut app1 = App::<Request, BasicContext>::new_basic();
 
     fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> MiddlewareReturnValue<BasicContext> {
-      context.body = context.params.get("id").unwrap().to_owned();
+      let body = &context.params.get("id").unwrap().clone();
+
+      context.body(body);
       Box::new(future::ok(context))
     };
 
     fn test_fn_2(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> MiddlewareReturnValue<BasicContext> {
-      context.body = "-1".to_owned();
+      context.body("-1");
       Box::new(future::ok(context))
     }
 
@@ -424,7 +435,9 @@ mod tests {
     let mut app = App::<Request, BasicContext>::new_basic();
 
     fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> MiddlewareReturnValue<BasicContext> {
-      context.body = context.params.get("id").unwrap().to_owned();
+      let body = &context.params.get("id").unwrap().clone();
+
+      context.body(body);
       Box::new(future::ok(context))
     };
 
@@ -468,12 +481,16 @@ mod tests {
     let mut app = App::<Request, BasicContext>::new_basic();
 
     fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
-      context.body = format!("{}{}", context.body, "1");
+      let existing_body = context.get_body().clone();
+
+      context.body(&format!("{}{}", existing_body, "1"));
       Box::new(future::ok(context))
     };
 
     fn test_fn_2(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
-      context.body = format!("{}{}", context.body, "2");
+      let existing_body = context.get_body().clone();
+
+      context.body(&format!("{}{}", existing_body, "2"));
       Box::new(future::ok(context))
     };
 
@@ -490,16 +507,22 @@ mod tests {
     let mut app = App::<Request, BasicContext>::new_basic();
 
     fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
-      context.body = format!("{}{}", context.body, "1");
+      let existing_body = context.get_body().clone();
+
+      context.body(&format!("{}{}", existing_body, "1"));
       Box::new(future::ok(context))
     };
 
     fn test_fn_2(mut context: BasicContext, next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
-      context.body = format!("{}{}", context.body, "2");
+      let existing_body = context.get_body().clone();
+
+      context.body(&format!("{}{}", existing_body, "2"));
 
       let context_with_body = next(context)
         .and_then(|mut _context| {
-          _context.body = format!("{}{}", _context.body, "2");
+          let _existing_body = _context.get_body().clone();
+
+          _context.body(&format!("{}{}", _existing_body, "2"));
           future::ok(_context)
         });
 
@@ -518,7 +541,7 @@ mod tests {
     let mut app = App::<Request, BasicContext>::new_basic();
 
     fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
-      context.body = "Hello world".to_owned();
+      context.body("Hello world");
       Box::new(future::ok(context))
     };
 
@@ -534,7 +557,7 @@ mod tests {
     let mut app = App::<Request, BasicContext>::new_basic();
 
     fn method_agnostic(mut context: BasicContext, next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
-      context.body = "agnostic".to_owned();
+      context.body("agnostic");
       let updated_context = next(context);
 
       let body_with_copied_context = updated_context
@@ -546,7 +569,9 @@ mod tests {
     }
 
     fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
-      context.body = format!("{}-1", context.body);
+      let body = context.get_body().clone();
+
+      context.body(&format!("{}-1", body));
       Box::new(future::ok(context))
     };
 
@@ -564,7 +589,7 @@ mod tests {
     let mut app1 = App::<Request, BasicContext>::new_basic();
 
     fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
-      context.body = "1".to_owned();
+      context.body("1");
       Box::new(future::ok(context))
     };
 
@@ -583,7 +608,7 @@ mod tests {
     let mut app1 = App::<Request, BasicContext>::new_basic();
 
     fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
-      context.body = "1".to_owned();
+      context.body("1");
       Box::new(future::ok(context))
     };
 
@@ -602,7 +627,7 @@ mod tests {
     let mut app1 = App::<Request, BasicContext>::new_basic();
 
     fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
-      context.body = "1".to_owned();
+      context.body("1");
       Box::new(future::ok(context))
     };
 
@@ -621,7 +646,7 @@ mod tests {
     let mut app1 = App::<Request, BasicContext>::new_basic();
 
     fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
-      context.body = "1".to_owned();
+      context.body("1");
       Box::new(future::ok(context))
     };
 
@@ -644,12 +669,12 @@ mod tests {
     let mut app = App::<Request, BasicContext>::new_basic();
 
     fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
-      context.body = "1".to_owned();
+      context.body("1");
       Box::new(future::ok(context))
     };
 
     fn test_404(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
-      context.body = "not found".to_owned();
+      context.body("not found");
       Box::new(future::ok(context))
     };
 
@@ -667,12 +692,12 @@ mod tests {
     let mut app = App::<Request, BasicContext>::new_basic();
 
     fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
-      context.body = "1".to_owned();
+      context.body("1");
       Box::new(future::ok(context))
     };
 
     fn test_404(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
-      context.body = "not found".to_owned();
+      context.body("not found");
       Box::new(future::ok(context))
     };
 
@@ -689,12 +714,12 @@ mod tests {
     let mut app = App::<Request, BasicContext>::new_basic();
 
     fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
-      context.body = "1".to_owned();
+      context.body("1");
       Box::new(future::ok(context))
     };
 
     fn test_404(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
-      context.body = "not found".to_owned();
+      context.body("not found");
       Box::new(future::ok(context))
     };
 
@@ -711,12 +736,12 @@ mod tests {
     let mut app = App::<Request, BasicContext>::new_basic();
 
     fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
-      context.body = "1".to_owned();
+      context.body("1");
       Box::new(future::ok(context))
     };
 
     fn test_404(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
-      context.body = "not found".to_owned();
+      context.body("not found");
       Box::new(future::ok(context))
     };
 
@@ -733,12 +758,12 @@ mod tests {
     let mut app = App::<Request, BasicContext>::new_basic();
 
     fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
-      context.body = "1".to_owned();
+      context.body("1");
       Box::new(future::ok(context))
     };
 
     fn test_404(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
-      context.body = "not found".to_owned();
+      context.body("not found");
       Box::new(future::ok(context))
     };
 
@@ -757,12 +782,12 @@ mod tests {
     let mut app3 = App::<Request, BasicContext>::new_basic();
 
     fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
-      context.body = "1".to_owned();
+      context.body("1");
       Box::new(future::ok(context))
     };
 
     fn test_404(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
-      context.body = "not found".to_owned();
+      context.body("not found");
       Box::new(future::ok(context))
     };
 
@@ -781,7 +806,7 @@ mod tests {
     let mut app = App::<Request, BasicContext>::new_basic();
 
     fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
-      context.body = "1".to_owned();
+      context.body("1");
       Box::new(future::ok(context))
     };
 
@@ -803,7 +828,7 @@ mod tests {
     let mut app2 = App::<Request, BasicContext>::new_basic();
 
     fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
-      context.body = "1".to_owned();
+      context.body("1");
       Box::new(future::ok(context))
     };
 
@@ -822,12 +847,12 @@ mod tests {
     let mut app3 = App::<Request, BasicContext>::new_basic();
 
     fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
-      context.body = "1".to_owned();
+      context.body("1");
       Box::new(future::ok(context))
     };
 
     fn test_fn_2(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
-      context.body = "2".to_owned();
+      context.body("2");
       Box::new(future::ok(context))
     };
 

--- a/src/builtins/basic_context.rs
+++ b/src/builtins/basic_context.rs
@@ -47,7 +47,7 @@ pub fn generate_context(request: Request) -> BasicContext {
 
 #[derive(Default)]
 pub struct BasicContext {
-  pub body: String,
+  body_bytes: Vec<u8>,
   pub params: HashMap<String, String>,
   pub query_params: HashMap<String, String>,
   pub request: Request,
@@ -58,13 +58,24 @@ pub struct BasicContext {
 impl BasicContext {
   pub fn new() -> BasicContext {
     BasicContext {
-      body: "".to_owned(),
+      body_bytes: Vec::new(),
       params: HashMap::new(),
       query_params: HashMap::new(),
       request: Request::new(),
       headers: HashMap::new(),
       status: 200
     }
+  }
+
+  ///
+  /// Set the body as a string
+  ///
+  pub fn body(&mut self, body_string: &str) {
+    self.body_bytes = body_string.as_bytes().to_vec();
+  }
+
+  pub fn get_body(&self) -> String {
+    str::from_utf8(&self.body_bytes).unwrap_or("").to_owned()
   }
 
   ///
@@ -164,7 +175,7 @@ impl Context for BasicContext {
   fn get_response(self) -> Self::Response {
     let mut response = Response::new();
 
-    response.body(&self.body);
+    response.body_bytes(&self.body_bytes);
 
     for (key, val) in self.headers {
       response.header(&key, &val);
@@ -176,7 +187,7 @@ impl Context for BasicContext {
   }
 
   fn set_body(&mut self, body: Vec<u8>) {
-    self.body = str::from_utf8(&body).unwrap_or("").to_owned();
+    self.body_bytes = body;
   }
 }
 

--- a/src/route_tree/mod.rs
+++ b/src/route_tree/mod.rs
@@ -134,7 +134,7 @@ mod tests {
     let mut route_tree = RouteTree::new();
 
     fn test_function(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> MiddlewareReturnValue<BasicContext> {
-      context.body = "Hello".to_string();
+      context.body("Hello");
 
       Box::new(future::ok(context))
     }
@@ -146,7 +146,7 @@ mod tests {
       .wait()
       .unwrap();
 
-    assert!(result.body == "Hello");
+    assert!(result.get_body() == "Hello");
   }
 
   #[test]
@@ -154,7 +154,9 @@ mod tests {
     let mut route_tree = RouteTree::new();
 
     fn test_function(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> MiddlewareReturnValue<BasicContext> {
-      context.body = context.params.get("key").unwrap().to_owned();
+      let body = &context.params.get("key").unwrap().clone();
+
+      context.body(body);
 
       Box::new(future::ok(context))
     }
@@ -169,7 +171,7 @@ mod tests {
       .wait()
       .unwrap();
 
-    assert!(result.body == "value");
+    assert!(result.get_body() == "value");
   }
 
   #[test]
@@ -179,7 +181,7 @@ mod tests {
     }
 
     fn test_function2(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> MiddlewareReturnValue<BasicContext> {
-      context.body = "Hello".to_string();
+      context.body("Hello");
 
       Box::new(future::ok(context))
     }
@@ -197,6 +199,6 @@ mod tests {
       .wait()
       .unwrap();
 
-    assert!(result.body == "Hello");
+    assert!(result.get_body() == "Hello");
   }
 }


### PR DESCRIPTION
Right now we automatically cast to utf8 into a BasicContext. This isn't tenable for non-string based files -- so now `BasicContext.set_body` will _not_ attempt to cast to utf8 prior to passing the data to the response.