### PR TITLE
Avoid unnnecessary String conversions in Hyper context

### DIFF
--- a/examples/hyper_most_basic.rs
+++ b/examples/hyper_most_basic.rs
@@ -6,14 +6,14 @@ use std::boxed::Box;
 use futures::future;
 
 use hyper::{Body, Request};
-use thruster::{App, MiddlewareChain, MiddlewareReturnValue};
+use thruster::{App, Context, MiddlewareChain, MiddlewareReturnValue};
 use thruster::builtins::hyper_server::Server;
 use thruster::builtins::basic_hyper_context::{generate_context, BasicHyperContext as Ctx};
 use thruster::server::ThrusterServer;
 
 fn plaintext(mut context: Ctx, _next: impl Fn(Ctx) -> MiddlewareReturnValue<Ctx>  + Send + Sync) -> MiddlewareReturnValue<Ctx> {
-  let val = "Hello, World!".to_owned();
-  context.body = val;
+  let val = "Hello, World!".as_bytes().to_vec();
+  context.set_body(val);
 
   Box::new(future::ok(context))
 }

--- a/src/builtins/basic_hyper_context.rs
+++ b/src/builtins/basic_hyper_context.rs
@@ -45,7 +45,7 @@ pub fn generate_context(request: Request<Body>) -> BasicHyperContext {
 
 #[derive(Default)]
 pub struct BasicHyperContext {
-  pub body: String,
+  pub body: Body,
   pub query_params: HashMap<String, String>,
   pub request: Request<Body>,
   pub status: u16,
@@ -61,7 +61,7 @@ impl BasicHyperContext {
     req.extensions_mut().insert(param_map);
 
     BasicHyperContext {
-      body: "".to_owned(),
+      body: Body::empty(),
       query_params: HashMap::new(),
       request: req,
       headers: HashMap::new(),
@@ -186,11 +186,11 @@ impl Context for BasicHyperContext {
 
     response_builder.status(StatusCode::from_u16(self.status).unwrap());
 
-    response_builder.body(Body::from(self.body)).unwrap()
+    response_builder.body(self.body).unwrap()
   }
 
   fn set_body(&mut self, body: Vec<u8>) {
-    self.body = str::from_utf8(&body).unwrap_or("").to_owned();
+    self.body = Body::from(body);
   }
 }
 


### PR DESCRIPTION
Now that `set_body` accepts a `Vec<u8>`, there's no need for this UTF8 check/conversion in the Hyper context. It can go directly into a Hyper `Body`, which should be a little more efficient. 