### PR TITLE
feat: Add better error handling [#108]

### DIFF
--- a/thruster-app/Cargo.toml
+++ b/thruster-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thruster-app"
-version = "0.7.5"
+version = "0.7.6"
 authors = ["Pete Mertz <peter.s.mertz@gmail.com>"]
 description = "The App portion of the thruster web framework"
 readme = "README.md"
@@ -21,6 +21,10 @@ thruster_async_await = [
   "thruster-core/thruster_async_await",
   "thruster-context/thruster_async_await",
   "thruster-async-await/thruster_async_await"
+]
+thruster_error_handling = [
+  "thruster-core/thruster_error_handling",
+  "thruster-async-await/thruster_error_handling"
 ]
 
 [dependencies]

--- a/thruster-app/src/app.rs
+++ b/thruster-app/src/app.rs
@@ -1,5 +1,6 @@
 use std::io;
 
+use futures::future;
 use futures::{Future as FutureLegacy};
 use thruster_core::context::Context;
 use thruster_core::request::{Request, RequestWithParams};

--- a/thruster-app/src/app.rs
+++ b/thruster-app/src/app.rs
@@ -1,6 +1,5 @@
 use std::io;
 
-use futures::future;
 use futures::{Future as FutureLegacy};
 use thruster_core::context::Context;
 use thruster_core::request::{Request, RequestWithParams};
@@ -217,6 +216,9 @@ impl<R: RequestWithParams, T: Context + Send> App<R, T> {
 
     let context = (self.context_generator)(request);
     let context_future = matched_route.middleware.run(context);
+
+    #[cfg(feature = "thruster_error_handling")]
+    let context_future = context_future.unwrap();
 
     context_future
         .and_then(|context| {

--- a/thruster-async-await/Cargo.toml
+++ b/thruster-async-await/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thruster-async-await"
-version = "0.7.5"
+version = "0.7.6"
 authors = ["Pete Mertz <peter.s.mertz@gmail.com>"]
 description = "An async await shim for the thruster web framework"
 readme = "README.md"
@@ -15,6 +15,9 @@ edition = "2018"
 default = ["thruster_async_await"]
 thruster_async_await = [
   "thruster-core/thruster_async_await"
+]
+thruster_error_handling = [
+  "thruster-core/thruster_error_handling"
 ]
 
 [dependencies]

--- a/thruster-async-await/src/lib.rs
+++ b/thruster-async-await/src/lib.rs
@@ -6,6 +6,7 @@ use futures_legacy::{Future as FutureLegacy};
 use thruster_core::context::Context;
 use thruster_core::request::{RequestWithParams};
 use thruster_core::route_parser::{MatchedRoute};
+use thruster_core::errors::Error;
 
 pub fn resolve<R: RequestWithParams, T: 'static + Context + Send>(context_generator: fn(R) -> T, mut request: R, matched_route: MatchedRoute<T>) -> impl FutureLegacy<Item=T::Response, Error=io::Error> + Send {
   use tokio_futures::compat::into_01;
@@ -17,6 +18,15 @@ pub fn resolve<R: RequestWithParams, T: 'static + Context + Send>(context_genera
   let copy = matched_route.middleware.clone();
   let context_future = async move {
     let ctx = copy.run(context).await;
+
+    #[cfg(feature = "thruster_error_handling")]
+    let ctx = match ctx {
+      Ok(val) => val,
+      Err(e) => {
+        e.build_context()
+      }
+    };
+
     Ok(ctx.get_response())
   };
 

--- a/thruster-context/Cargo.toml
+++ b/thruster-context/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thruster-context"
-version = "0.7.5"
+version = "0.7.6"
 authors = ["Pete Mertz <peter.s.mertz@gmail.com>"]
 description = "The context portion of the thruster web framework"
 readme = "README.md"
@@ -18,6 +18,9 @@ hyper_server = [
 ]
 thruster_async_await = [
   "thruster-core/thruster_async_await"
+]
+thruster_error_handling = [
+  "thruster-core/thruster_error_handling"
 ]
 
 [dependencies]

--- a/thruster-core-async-await/Cargo.toml
+++ b/thruster-core-async-await/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thruster-core-async-await"
-version = "0.7.5"
+version = "0.7.6"
 authors = ["Pete Mertz <peter.s.mertz@gmail.com>"]
 description = "An async await shim for the core features of the thruster web framework"
 readme = "README.md"
@@ -13,6 +13,7 @@ edition = "2018"
 
 [features]
 thruster_async_await = []
+thruster_error_handling = []
 
 [dependencies]
 futures-legacy = { version = "0.1.23", package = "futures" }

--- a/thruster-core-async-await/src/errors.rs
+++ b/thruster-core-async-await/src/errors.rs
@@ -1,0 +1,6 @@
+#[derive(Debug)]
+pub struct ThrusterError<C> {
+  pub context: C,
+  pub message: String,
+  pub status: u32
+}

--- a/thruster-core-async-await/src/lib.rs
+++ b/thruster-core-async-await/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod middleware;
+pub mod errors;
 
 pub use crate::middleware::*;

--- a/thruster-core-async-await/src/middleware.rs
+++ b/thruster-core-async-await/src/middleware.rs
@@ -1,11 +1,25 @@
 use std::boxed::Box;
 use futures::future::Future;
 use std::pin::Pin;
+use crate::errors::ThrusterError;
 
+#[cfg(not(feature = "thruster_error_handling"))]
+pub type MiddlewareResult<C> = C;
+#[cfg(not(feature = "thruster_error_handling"))]
 pub type MiddlewareReturnValue<T> = Pin<Box<Future<Output=T> + Send + Sync>>;
+#[cfg(not(feature = "thruster_error_handling"))]
 pub type MiddlewareNext<C> = Box<Fn(C) -> Pin<Box<Future<Output=C> + Send + Sync>> + Send + Sync>;
-
+#[cfg(not(feature = "thruster_error_handling"))]
 type MiddlewareFn<C> = fn(C, Box<((Fn(C) -> Pin<Box<Future<Output=C> + Send + Sync>>) + 'static + Send + Sync)>) -> Pin<Box<Future<Output=C> + Send + Sync>>;
+
+#[cfg(feature = "thruster_error_handling")]
+pub type MiddlewareResult<C> = Result<C, ThrusterError<C>>;
+#[cfg(feature = "thruster_error_handling")]
+pub type MiddlewareReturnValue<C> = Pin<Box<Future<Output=MiddlewareResult<C>> + Send + Sync>>;
+#[cfg(feature = "thruster_error_handling")]
+pub type MiddlewareNext<C> = Box<Fn(C) -> Pin<Box<Future<Output=MiddlewareResult<C>> + Send + Sync>> + Send + Sync>;
+#[cfg(feature = "thruster_error_handling")]
+type MiddlewareFn<C> = fn(C, Box<((Fn(C) -> Pin<Box<Future<Output=MiddlewareResult<C>> + Send + Sync>>) + 'static + Send + Sync)>) -> Pin<Box<Future<Output=MiddlewareResult<C>> + Send + Sync>>;
 
 pub struct Middleware<C: 'static> {
   pub middleware: &'static [
@@ -40,7 +54,7 @@ impl<C: 'static> Chain<C> {
     }
   }
 
-  fn chained_run(&self, i: usize, j: usize) -> Box<Fn(C) -> Pin<Box<Future<Output=C> + Send + Sync>> + Send + Sync> {
+  fn chained_run(&self, i: usize, j: usize) -> Box<Fn(C) -> Pin<Box<Future<Output=MiddlewareResult<C>> + Send + Sync>> + Send + Sync> {
     chained_run(i, j, self.nodes.clone())
   }
 
@@ -48,7 +62,7 @@ impl<C: 'static> Chain<C> {
     self.built = self.chained_run(0, 0);
   }
 
-  fn run(&self, context: C) -> Pin<Box<Future<Output=C> + Send + Sync>> {
+  fn run(&self, context: C) -> Pin<Box<Future<Output=MiddlewareResult<C>> + Send + Sync>> {
     (self.built)(context)
   }
 }
@@ -97,7 +111,13 @@ impl<T: 'static> MiddlewareChain<T> {
   ///
   /// Run the middleware chain once
   ///
+  #[cfg(not(feature = "thruster_error_handling"))]
   pub fn run(&self, context: T) -> Pin<Box<Future<Output=T> + Send + Sync>> {
+    self.chain.run(context)
+  }
+
+  #[cfg(feature = "thruster_error_handling")]
+  pub fn run(&self, context: T) -> Pin<Box<Future<Output=MiddlewareResult<T>> + Send + Sync>> {
     self.chain.run(context)
   }
 

--- a/thruster-core/Cargo.toml
+++ b/thruster-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thruster-core"
-version = "0.7.5"
+version = "0.7.6"
 authors = ["Pete Mertz <peter.s.mertz@gmail.com>"]
 description = "The core pieces of the thruster web framework"
 readme = "README.md"
@@ -14,6 +14,9 @@ edition = "2018"
 [features]
 thruster_async_await = [
   "thruster-core-async-await/thruster_async_await"
+]
+thruster_error_handling = [
+  "thruster-core-async-await/thruster_error_handling"
 ]
 
 [dependencies]

--- a/thruster-core/src/errors.rs
+++ b/thruster-core/src/errors.rs
@@ -1,0 +1,15 @@
+pub use thruster_core_async_await::errors::ThrusterError;
+use crate::context::Context;
+
+pub trait Error<C> {
+  fn build_context(self) -> C;
+}
+
+impl<C: Context> Error<C> for ThrusterError<C> {
+  fn build_context(self) -> C {
+    let mut context = self.context;
+
+    context.set_body(format!("{{\"message\": \"{}\",\"success\":false}}", self.message).as_bytes().to_vec());
+    context
+  }
+}

--- a/thruster-core/src/lib.rs
+++ b/thruster-core/src/lib.rs
@@ -5,6 +5,8 @@ extern crate http as httplib;
 
 #[cfg(not(feature = "thruster_async_await"))]
 #[macro_use] pub mod middleware;
+#[cfg(feature = "thruster_error_handling")]
+#[macro_use] pub mod macros;
 
 pub mod date;
 pub mod http;
@@ -13,11 +15,14 @@ pub mod response;
 pub mod context;
 pub mod route_parser;
 pub mod route_tree;
+#[cfg(feature = "thruster_error_handling")]
+pub mod errors;
 
 #[cfg(not(feature = "thruster_async_await"))]
 pub use crate::middleware::*;
-
 #[cfg(feature = "thruster_async_await")]
 pub use thruster_core_async_await::{Chain, Middleware, MiddlewareChain, MiddlewareNext, MiddlewareReturnValue};
 #[cfg(feature = "thruster_async_await")]
 pub use thruster_core_async_await::middleware;
+#[cfg(feature = "thruster_error_handling")]
+pub use thruster_core_async_await::{MiddlewareResult};

--- a/thruster-core/src/macros.rs
+++ b/thruster-core/src/macros.rs
@@ -1,0 +1,13 @@
+#[macro_export]
+macro_rules! map_try {
+  [ $expr:expr, $pat:pat => $mapper:block ] => ({
+    match $expr {
+        Ok(val) => val,
+        $pat => {
+            let __e = $mapper;
+
+            return Err(__e);
+        }
+    }
+  });
+}

--- a/thruster-core/src/macros.rs
+++ b/thruster-core/src/macros.rs
@@ -1,6 +1,6 @@
 #[macro_export]
 macro_rules! map_try {
-  [ $expr:expr, $pat:pat => $mapper:block ] => ({
+  [ $expr:expr, $pat:pat => $mapper:expr ] => ({
     match $expr {
         Ok(val) => val,
         $pat => {

--- a/thruster-middleware/Cargo.toml
+++ b/thruster-middleware/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thruster-middleware"
-version = "0.7.5"
+version = "0.7.6"
 authors = ["Pete Mertz <peter.s.mertz@gmail.com>"]
 description = "The middleware for the thruster web framework"
 readme = "README.md"

--- a/thruster-proc/Cargo.toml
+++ b/thruster-proc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thruster-proc"
-version = "0.7.5"
+version = "0.7.6"
 authors = ["Pete Mertz <peter.s.mertz@gmail.com>"]
 description = "The proc macros behind the thruster web framework"
 readme = "README.md"

--- a/thruster-proc/src/lib.rs
+++ b/thruster-proc/src/lib.rs
@@ -1,3 +1,6 @@
+#![feature(proc_macro_diagnostic, proc_macro_span)]
+#![feature(await_macro, async_await, futures_api, proc_macro_hygiene)]
+
 extern crate proc_macro;
 extern crate proc_macro2;
 extern crate lazy_static;
@@ -72,6 +75,12 @@ pub fn middleware_fn(_attr: TokenStream, item: TokenStream) -> TokenStream {
                 Box::pin(#new_name(ctx, next))
             }
         };
+
+        // proc_macro::Span::call_site()
+        //     .note("Thruster code output")
+        //     .note(gen.to_string())
+        //     .emit();
+
         gen.into()
     } else {
         item

--- a/thruster-server/Cargo.toml
+++ b/thruster-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thruster-server"
-version = "0.7.5"
+version = "0.7.6"
 authors = ["Pete Mertz <peter.s.mertz@gmail.com>"]
 description = "The core future wrappers aroun the thruster web framework"
 readme = "README.md"

--- a/thruster/Cargo.toml
+++ b/thruster/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thruster"
-version = "0.7.5"
+version = "0.7.6"
 authors = ["Pete Mertz <peter.s.mertz@gmail.com>"]
 description = "A middleware based http async web server."
 readme = "README.md"
@@ -29,10 +29,15 @@ hyper_server = [
   "thruster-server/hyper_server"
 ]
 thruster_async_await = [
+  "thruster-proc",
   "thruster-app/thruster_async_await",
   "thruster-core/thruster_async_await",
   "thruster-context/thruster_async_await",
   "thruster-server/thruster_async_await"
+]
+thruster_error_handling = [
+  "thruster-core/thruster_error_handling",
+  "thruster-app/thruster_error_handling"
 ]
 
 [dependencies]
@@ -41,7 +46,7 @@ thruster-app = { version = "0.7", path = "../thruster-app" }
 thruster-context = { version = "0.7", path = "../thruster-context" }
 thruster-core = { version = "0.7", path = "../thruster-core" }
 thruster-middleware = { version = "0.7", path = "../thruster-middleware" }
-thruster-proc = { version = "0.7", path = "../thruster-proc" }
+thruster-proc = { version = "0.7", path = "../thruster-proc", optional = true }
 thruster-server = { version = "0.7", path = "../thruster-server" }
 
 [dev-dependencies]

--- a/thruster/src/lib.rs
+++ b/thruster/src/lib.rs
@@ -7,7 +7,7 @@ pub use thruster_core::request::{decode, Request};
 pub use thruster_core::http::Http;
 #[cfg(feature = "thruster_error_handling")]
 pub use thruster_core::{errors, map_try};
-
+#[cfg(feature = "thruster_error_handling")]
 pub use thruster_core::middleware::MiddlewareResult;
 
 #[cfg(not(feature = "thruster_async_await"))]

--- a/thruster/src/lib.rs
+++ b/thruster/src/lib.rs
@@ -5,6 +5,10 @@ pub use thruster_core::context::Context;
 pub use thruster_core::response::{encode, Response};
 pub use thruster_core::request::{decode, Request};
 pub use thruster_core::http::Http;
+#[cfg(feature = "thruster_error_handling")]
+pub use thruster_core::{errors, map_try};
+
+pub use thruster_core::middleware::MiddlewareResult;
 
 #[cfg(not(feature = "thruster_async_await"))]
 pub use thruster_core::{middleware, Middleware, MiddlewareChain, MiddlewareReturnValue};
@@ -21,6 +25,7 @@ pub use thruster_server::server;
 pub use thruster_server::thruster_server::ThrusterServer;
 pub use thruster_context;
 pub use thruster_context::basic_context::BasicContext;
+#[cfg(feature = "thruster_async_await")]
 pub use thruster_proc;
 
 #[cfg(feature="hyper_server")]


### PR DESCRIPTION
Adds better error handling via a new macro -- `map_try`.

Error handling in Thruster at the moment is painful to say the least. It usually involves multiple levels of error handling and far too much indentation, or it involves layers of enums and implementations of contexts.

Ideally, we'd be able to simply have the solution:

```rust
async fn endpoint(context: BasicContext, next: MiddlewareNext<BasicContext>) -> Result<Ctx, ThrusterError> {
  let s = some_call()?;

  context.body(s);

  Ok(context)
}
```

However, in order for the error to be properly mapped down the line, the resulting calls to `next` need access to a context, as the `context` they were supplied with as an argument is moved when `next(context)` is called. This means we need a thruster specific error, `ThrusterError`, that contains a context. Naively we would think that this should work:

```rust
async fn endpoint(context: BasicContext, next: MiddlewareNext<BasicContext>) -> Result<Ctx, ThrusterError> {
  let s = some_call()
    .map_err(|_| {
      Error {
        context,
        message: "Parsing failure!".to_string(),
        status: 400
      }
    })?;

  context.body(s);

  Ok(context)
}
```

However, the compiler isn't clever enough to see that if `map_err` is called, then `context.body` is not thanks to the `?` operator.

If we are explicit about this using a match, like the expansion of `try!`, however, the compiler sees the code paths and is able to adjust accordingly. This PR adds `map_try!`, which does just that and allows for a mapping block to correctly convert the error type.

```
async fn endpoint(context: BasicContext, next: MiddlewareNext<BasicContext>) -> Result<Ctx, ThrusterError> {
  let res = "Hello, world".parse::<u32>();
  let non_existent_param = map_try!(res, Err(_) => {
      Error {
        context,
        message: "Parsing failure!".to_string(),
        status: 400
      }
    }
  );

  context.body(&format!("{}", non_existent_param));

  Ok(context)
}
```

Full example:

```rust
extern crate thruster;

use thruster::{MiddlewareNext, MiddlewareReturnValue, MiddlewareResult};
use thruster::{App, BasicContext as Ctx, Request, map_try};
use thruster::server::Server;
use thruster::errors::ThrusterError as Error;
use thruster::ThrusterServer;
use thruster::thruster_proc::{async_middleware, middleware_fn};

async fn plaintext(mut context: Ctx, _next: MiddlewareNext<Ctx>) -> MiddlewareResult<Ctx> {
  let val = "Hello, World!";
  context.body(val);
  Ok(context)
}

async fn error(mut context: Ctx, _next: MiddlewareNext<Ctx>) -> MiddlewareResult<Ctx> {
  let res = "Hello, world".parse::<u32>();
  let non_existent_param = map_try!(res, Err(_) => {
      Error {
        context,
        message: "Parsing failure!".to_string(),
        status: 400
      }
    }
  );

  context.body(&format!("{}", non_existent_param));

  Ok(context)
}

async fn json_error_handler(context: Ctx, next: MiddlewareNext<Ctx>) -> MiddlewareResult<Ctx> {
  let res = await!(next(context));

  let ctx = match res {
    Ok(val) => val,
    Err(e) => {
      let mut context = e.context;
      context.body(&format!("{{\"message\": \"{}\",\"success\":false}}", e.message));
      context.status(e.status);
      context
    }
  };

  Ok(ctx)
}

fn main() {
  println!("Starting server...");

  let mut app = App::<Request, Ctx>::new_basic();

  app.use_middleware("/", async_middleware!(Ctx, [json_error_handler]));

  app.get("/plaintext", async_middleware!(Ctx, [plaintext]));
  app.get("/error", async_middleware!(Ctx, [error]));

  let server = Server::new(app);
  server.start("0.0.0.0", 4321);
}
```

Delivers [#108]