### PR TITLE
chore: Update tokio to use most recent `.await` syntax [#111]

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ _Note:, for the short term, the argument style of this macro has changed from `m
 A simple example for using async await is:
 
 ```rust
-#![feature(await_macro, async_await, futures_api, proc_macro_hygiene)]
+#![feature(async_await, proc_macro_hygiene)]
 extern crate thruster;
 
 use std::boxed::Box;
@@ -162,7 +162,7 @@ use thruster::thruster_proc::{async_middleware, middleware_fn};
 async fn profile(context: Ctx, next: MiddlewareNext<Ctx>) -> Ctx {
   let start_time = Instant::now();
 
-  context = await!(next(context));
+  context = next(context).await;
 
   let elapsed_time = start_time.elapsed();
   println!("[{}μs] {} -- {}",

--- a/thruster-async-await/Cargo.toml
+++ b/thruster-async-await/Cargo.toml
@@ -19,9 +19,9 @@ thruster_async_await = [
 
 [dependencies]
 futures-legacy = { version = "0.1.23", package = "futures" }
-futures-preview = "0.3.0-alpha.13"
+futures-preview = "0.3.0-alpha.16"
 futures-util = "0.2.1"
 thruster-core = { version = "0.7", path = "../thruster-core" }
-tokio = { version = "0.1.15", features = ["async-await-preview"] }
-tokio-async-await = "0.1.6"
+tokio = { git = "https://github.com/tokio-rs/tokio", branch = "master" }
+tokio-futures = { git = "https://github.com/tokio-rs/tokio", branch = "master", features = ["async-await-preview"] }
 

--- a/thruster-async-await/src/lib.rs
+++ b/thruster-async-await/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(await_macro, async_await, futures_api, proc_macro_hygiene)]
+#![feature(async_await, proc_macro_hygiene)]
 
 use std::io;
 use futures_legacy::{Future as FutureLegacy};
@@ -8,18 +8,17 @@ use thruster_core::request::{RequestWithParams};
 use thruster_core::route_parser::{MatchedRoute};
 
 pub fn resolve<R: RequestWithParams, T: 'static + Context + Send>(context_generator: fn(R) -> T, mut request: R, matched_route: MatchedRoute<T>) -> impl FutureLegacy<Item=T::Response, Error=io::Error> + Send {
-  use tokio_async_await::compat::backward;
+  use tokio_futures::compat::into_01;
 
   request.set_params(matched_route.params);
 
   let context = (context_generator)(request);
-  let middleware = matched_route.middleware;
 
   let copy = matched_route.middleware.clone();
   let context_future = async move {
-    let ctx = await!(copy.run(context));
+    let ctx = copy.run(context).await;
     Ok(ctx.get_response())
   };
 
-  backward::Compat::new(context_future)
+  into_01(context_future)
 }

--- a/thruster-core-async-await/Cargo.toml
+++ b/thruster-core-async-await/Cargo.toml
@@ -16,4 +16,4 @@ thruster_async_await = []
 
 [dependencies]
 futures-legacy = { version = "0.1.23", package = "futures" }
-futures-preview = "0.3.0-alpha.13"
+futures-preview = "0.3.0-alpha.16"

--- a/thruster-core-async-await/src/lib.rs
+++ b/thruster-core-async-await/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(futures_api)]
-
 pub mod middleware;
 
 pub use crate::middleware::*;

--- a/thruster-core/Cargo.toml
+++ b/thruster-core/Cargo.toml
@@ -21,13 +21,13 @@ bytes = "0.4"
 futures = "0.1.23"
 http = "0.1.7"
 httparse = "1.1.2"
-regex = "0.2"
+regex = "1.1.6"
 serde = "1.0.24"
 serde_json = "1.0.8"
 serde_derive = "1.0.24"
 smallvec = "0.6.2"
 templatify = "0.2.3"
 time = "0.1"
-tokio-codec = "0.1.0"
-tokio-io = "0.1"
+tokio-codec = { git = "https://github.com/tokio-rs/tokio", branch = "master" }
+tokio-io = { git = "https://github.com/tokio-rs/tokio", branch = "master" }
 thruster-core-async-await = { version = "0.7", path = "../thruster-core-async-await", optional = true }

--- a/thruster-middleware/Cargo.toml
+++ b/thruster-middleware/Cargo.toml
@@ -21,6 +21,6 @@ futures-legacy = { version = "0.1.23", package = "futures" }
 hyper = { version = "0.12.25", optional = true }
 net2 = "0.2"
 num_cpus = "1.0"
-tokio = "0.1.15"
-tokio-codec = "0.1.0"
+tokio = { git = "https://github.com/tokio-rs/tokio", branch = "master" }
+tokio-codec = { git = "https://github.com/tokio-rs/tokio", branch = "master" }
 thruster-core = { version = "0.7", path = "../thruster-core" }

--- a/thruster-server/Cargo.toml
+++ b/thruster-server/Cargo.toml
@@ -12,9 +12,7 @@ repository = "https://github.com/trezm/thruster"
 edition = "2018"
 
 [features]
-thruster_async_await = [
-  "tokio/async-await-preview"
-]
+thruster_async_await = []
 hyper_server = [
   "hyper",
   "thruster-context/hyper_server"
@@ -25,8 +23,8 @@ futures-legacy = { version = "0.1.23", package = "futures" }
 hyper = { version = "0.12.25", optional = true }
 net2 = "0.2"
 num_cpus = "1.0"
-tokio = "0.1.15"
-tokio-codec = "0.1.0"
+tokio = { git = "https://github.com/tokio-rs/tokio", branch = "master" }
+tokio-codec = { git = "https://github.com/tokio-rs/tokio", branch = "master" }
 thruster-core = { version = "0.7", path = "../thruster-core" }
 thruster-app = { version = "0.7", path = "../thruster-app" }
 thruster-context = { version = "0.7", path = "../thruster-context" }

--- a/thruster/examples/most_basic_async.rs
+++ b/thruster/examples/most_basic_async.rs
@@ -1,4 +1,4 @@
-#![feature(await_macro, async_await, futures_api, proc_macro_hygiene)]
+#![feature(async_await, proc_macro_hygiene)]
 extern crate thruster;
 
 use std::time::Instant;
@@ -12,7 +12,7 @@ use thruster::thruster_proc::{async_middleware, middleware_fn};
 async fn profiling(mut context: Ctx, next: MiddlewareNext<Ctx>) -> Ctx {
   let start_time = Instant::now();
 
-  context = await!(next(context));
+  context = next(context).await;
 
   let elapsed_time = start_time.elapsed();
   println!("[{}μs] {} -- {}",
@@ -25,7 +25,7 @@ async fn profiling(mut context: Ctx, next: MiddlewareNext<Ctx>) -> Ctx {
 
 #[middleware_fn]
 async fn add_one(context: Ctx, next: MiddlewareNext<Ctx>) -> Ctx {
-  let mut ctx: Ctx = await!(next(context));
+  let mut ctx: Ctx = next(context).await;
 
   ctx.body(&format!("{} + 1", ctx.get_body()));
   ctx


### PR DESCRIPTION
**Note:** Also had to switch to tokio master thanks to [this](https://github.com/tokio-rs/tokio/issues/1087#issuecomment-491901368).

Delivers [#111]