### PR TITLE
Example error handling

### DIFF
--- a/thruster/Cargo.toml
+++ b/thruster/Cargo.toml
@@ -18,6 +18,10 @@ debug = true
 name = "most_basic_async"
 required-features = ["thruster_async_await"]
 
+[[example]]
+name = "errors_async"
+required-features = ["thruster_async_await"]
+
 [[bench]]
 name = "app"
 harness = false
@@ -58,3 +62,4 @@ serde = "1.0.24"
 serde_json = "1.0.8"
 serde_derive = "1.0.24"
 smallvec = "0.6.2"
+snafu = "0.4.1"

--- a/thruster/Cargo.toml
+++ b/thruster/Cargo.toml
@@ -20,7 +20,7 @@ required-features = ["thruster_async_await"]
 
 [[example]]
 name = "errors_async"
-required-features = ["thruster_async_await"]
+required-features = ["thruster_async_await", "thruster_error_handling"]
 
 [[bench]]
 name = "app"

--- a/thruster/examples/errors_async.rs
+++ b/thruster/examples/errors_async.rs
@@ -1,0 +1,106 @@
+#![feature(async_await, proc_macro_hygiene)]
+extern crate thruster;
+
+use snafu::{ResultExt, Snafu};
+
+use thruster::{MiddlewareNext, MiddlewareReturnValue, MiddlewareResult};
+use thruster::{App, BasicContext as Ctx, Request, map_try};
+use thruster::server::Server;
+use thruster::errors::ThrusterError;
+use thruster::ThrusterServer;
+use thruster::thruster_proc::{async_middleware, middleware_fn};
+
+#[derive(Debug, Snafu)]
+enum Error {
+  #[snafu(display("Could not parse id: {}", id))]
+  InvalidId { id: String, source: std::num::ParseIntError },
+
+  #[snafu(display("Could not open config at {}: {}", filename.display(), source))]
+  FileNotFound {
+    filename: std::path::PathBuf,
+    source: std::io::Error,
+  }
+}
+
+trait ErrorExt {
+  fn context(self, context: Ctx) -> ThrusterError<Ctx>;
+}
+
+impl<E: Into<Error>> ErrorExt for E {
+  fn context(self, context: Ctx) -> ThrusterError<Ctx> {
+    ThrusterError {
+      context,
+      message: "Failed to handle error".to_string(),
+      status: 500,
+      cause: Some(Box::new(self.into()))
+    }
+  }
+}
+
+#[middleware_fn]
+async fn json_error_handler(context: Ctx, next: MiddlewareNext<Ctx>) -> MiddlewareResult<Ctx> {
+  let res = next(context).await;
+
+  // If there is not an error, return
+  let mut err = match res {
+    Ok(_) => return res,
+    Err(err) => err
+  };
+
+  // Generic handler, if we fail to downcast
+  let e: Box<Error> = match err.cause.take().map(|cause| cause.downcast()) {
+    Some(Ok(e)) => e,
+    _ => {
+      let mut context = err.context;
+
+      context.body(&format!("{{\"message\": \"{}\",\"success\":false}}", err.message));
+      context.status(err.status);
+
+      return Ok(context);
+    }
+  };
+
+  // Handle the Error variants
+  let mut context = err.context;
+  let status = match *e {
+    Error::InvalidId { .. } => 400,
+    Error::FileNotFound { .. } => 404,
+  };
+
+  context.status(status);
+  context.body(&format!("{{\"message\": \"{}\",\"success\":false}}", e));
+
+  Ok(context)
+}
+
+#[middleware_fn]
+async fn error(mut context: Ctx, _next: MiddlewareNext<Ctx>) -> MiddlewareResult<Ctx> {
+  let id = String::from("Hello, world");
+  let res = id.parse::<u32>().context(InvalidId { id });
+  let non_existent_param = map_try!(res, Err(err) => err.context(context));
+
+  context.body(&format!("{}", non_existent_param));
+
+  Ok(context)
+}
+
+#[middleware_fn]
+async fn four_oh_four(mut context: Ctx, _next: MiddlewareNext<Ctx>) -> MiddlewareResult<Ctx> {
+  context.status(404);
+  context.body("Whoops! That route doesn't exist!");
+  Ok(context)
+}
+
+fn main() {
+  println!("Starting server...");
+
+  let mut app = App::<Request, Ctx>::new_basic();
+
+  app.use_middleware("/", async_middleware!(Ctx, [json_error_handler]));
+
+  app.get("/error", async_middleware!(Ctx, [error]));
+  app.set404(async_middleware!(Ctx, [four_oh_four]));
+
+  let server = Server::new(app);
+  server.start("0.0.0.0", 4321);
+}


### PR DESCRIPTION
To help with complex error handling on `ThrusterError` I added some convenience methods for downcasting the cause.

An additional proposal is to implement `StdError` for `ThrusterError` with `fn cause` returning the cause.

Thoughts?