### PR TITLE
bug: Fix multiple packets for a single request

### DIFF
--- a/thruster-app/Cargo.toml
+++ b/thruster-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thruster-app"
-version = "0.7.7"
+version = "0.7.8"
 authors = ["Pete Mertz <peter.s.mertz@gmail.com>"]
 description = "The App portion of the thruster web framework"
 readme = "README.md"

--- a/thruster-async-await/Cargo.toml
+++ b/thruster-async-await/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thruster-async-await"
-version = "0.7.7"
+version = "0.7.8"
 authors = ["Pete Mertz <peter.s.mertz@gmail.com>"]
 description = "An async await shim for the thruster web framework"
 readme = "README.md"

--- a/thruster-context/Cargo.toml
+++ b/thruster-context/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thruster-context"
-version = "0.7.7"
+version = "0.7.8"
 authors = ["Pete Mertz <peter.s.mertz@gmail.com>"]
 description = "The context portion of the thruster web framework"
 readme = "README.md"

--- a/thruster-core-async-await/Cargo.toml
+++ b/thruster-core-async-await/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thruster-core-async-await"
-version = "0.7.7"
+version = "0.7.8"
 authors = ["Pete Mertz <peter.s.mertz@gmail.com>"]
 description = "An async await shim for the core features of the thruster web framework"
 readme = "README.md"

--- a/thruster-core/Cargo.toml
+++ b/thruster-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thruster-core"
-version = "0.7.7"
+version = "0.7.8"
 authors = ["Pete Mertz <peter.s.mertz@gmail.com>"]
 description = "The core pieces of the thruster web framework"
 readme = "README.md"

--- a/thruster-core/src/request.rs
+++ b/thruster-core/src/request.rs
@@ -180,13 +180,17 @@ pub fn decode(buf: &mut BytesMut) -> io::Result<Option<Request>> {
          body_len)
     };
 
-    Ok(Request {
-        method,
-        path,
-        version,
-        headers,
-        data: buf.split_to(amt + body_len),
-        body: (amt, amt + body_len),
-        params: HashMap::new()
-    }.into())
+    if amt + body_len != buf.len() {
+        Ok(None)
+    } else {
+        Ok(Request {
+            method,
+            path,
+            version,
+            headers,
+            data: buf.split_to(amt + body_len),
+            body: (amt, amt + body_len),
+            params: HashMap::new()
+        }.into())
+    }
 }

--- a/thruster-middleware/Cargo.toml
+++ b/thruster-middleware/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thruster-middleware"
-version = "0.7.7"
+version = "0.7.8"
 authors = ["Pete Mertz <peter.s.mertz@gmail.com>"]
 description = "The middleware for the thruster web framework"
 readme = "README.md"

--- a/thruster-proc/Cargo.toml
+++ b/thruster-proc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thruster-proc"
-version = "0.7.7"
+version = "0.7.8"
 authors = ["Pete Mertz <peter.s.mertz@gmail.com>"]
 description = "The proc macros behind the thruster web framework"
 readme = "README.md"

--- a/thruster-server/Cargo.toml
+++ b/thruster-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thruster-server"
-version = "0.7.7"
+version = "0.7.8"
 authors = ["Pete Mertz <peter.s.mertz@gmail.com>"]
 description = "The core future wrappers aroun the thruster web framework"
 readme = "README.md"

--- a/thruster-server/src/server.rs
+++ b/thruster-server/src/server.rs
@@ -131,7 +131,9 @@ impl<T: Context<Response = Response> + Send> ThrusterServer for Server<T> {
             let matched = app.resolve_from_method_and_path(request.method(), request.path());
             app.resolve(request, matched)
           }))
-          .then(|_| future::ok(()));
+          .then(|_| {
+            future::ok(())
+          });
 
       // Spawn the task that handles the connection.
       tokio::spawn(task);

--- a/thruster/Cargo.toml
+++ b/thruster/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thruster"
-version = "0.7.7"
+version = "0.7.8"
 authors = ["Pete Mertz <peter.s.mertz@gmail.com>"]
 description = "A middleware based http async web server."
 readme = "README.md"


### PR DESCRIPTION
**Problem:** Currently, if a stream sends the headers and then doesn't immediately send the rest of the data, the connection drops the client (because Thruster panics since it doesn't have the right amount of data.)

**Solution:** If the buffer size doesn't equal the content-length, then we return `Ok(None)` so that we wait for more data in the stream.