### PR TITLE
bug: Fix optimized route issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ script:
   - cd thruster
   # fail when encountering warnings
   - cargo clippy -- -D warnings
+  # run integration tests
+  - cargo test --test integration --features="thruster_async_await"
   # run app tests
   - cd ../thruster-app
   - cargo test

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ script:
   # fail when encountering warnings
   - cargo clippy -- -D warnings
   # run integration tests
-  - cargo test --test integration --features="thruster_async_await"
+  - cargo test --test integration
   # run app tests
   - cd ../thruster-app
   - cargo test

--- a/thruster-app/Cargo.toml
+++ b/thruster-app/Cargo.toml
@@ -20,7 +20,8 @@ hyper_server = []
 thruster_async_await = [
   "thruster-core/thruster_async_await",
   "thruster-context/thruster_async_await",
-  "thruster-async-await/thruster_async_await"
+  "thruster-async-await/thruster_async_await",
+  "thruster-proc"
 ]
 thruster_error_handling = [
   "thruster-core/thruster_error_handling",
@@ -35,4 +36,4 @@ thruster-async-await = { version = "0.7", path = "../thruster-async-await", opti
 thruster-context = { version = "0.7", path = "../thruster-context" }
 thruster-core = { version = "0.7", path = "../thruster-core" }
 thruster-middleware = { version = "0.7", path = "../thruster-middleware" }
-thruster-proc = { version = "0.7", path = "../thruster-proc" }
+thruster-proc = { version = "0.7", path = "../thruster-proc", optional = true }

--- a/thruster-app/Cargo.toml
+++ b/thruster-app/Cargo.toml
@@ -35,3 +35,4 @@ thruster-async-await = { version = "0.7", path = "../thruster-async-await", opti
 thruster-context = { version = "0.7", path = "../thruster-context" }
 thruster-core = { version = "0.7", path = "../thruster-core" }
 thruster-middleware = { version = "0.7", path = "../thruster-middleware" }
+thruster-proc = { version = "0.7", path = "../thruster-proc" }

--- a/thruster-app/src/app.rs
+++ b/thruster-app/src/app.rs
@@ -253,7 +253,7 @@ mod tests {
   fn it_should_execute_all_middlware_with_a_given_request() {
     let mut app = App::<Request, BasicContext>::new_basic();
 
-    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<dyn Future<Item=BasicContext, Error=io::Error> + Send> {
       context.body("1");
       Box::new(future::ok(context))
     };
@@ -270,12 +270,12 @@ mod tests {
   fn it_should_correctly_differentiate_wildcards_and_valid_routes() {
     let mut app = App::<Request, BasicContext>::new_basic();
 
-    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<dyn Future<Item=BasicContext, Error=io::Error> + Send> {
       context.body("1");
       Box::new(future::ok(context))
     };
 
-    fn test_fn_404(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_fn_404(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<dyn Future<Item=BasicContext, Error=io::Error> + Send> {
       context.body("2");
       Box::new(future::ok(context))
     };
@@ -293,7 +293,7 @@ mod tests {
   fn it_should_handle_query_parameters() {
     let mut app = App::<Request, BasicContext>::new_basic();
 
-    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<dyn Future<Item=BasicContext, Error=io::Error> + Send> {
       let body = &context.query_params.get("hello").unwrap().clone();
 
       context.body(body);
@@ -312,7 +312,7 @@ mod tests {
   fn it_should_handle_cookies() {
     let mut app = App::<Request, BasicContext>::new_basic();
 
-    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<dyn Future<Item=BasicContext, Error=io::Error> + Send> {
       let body = match context.cookies.get(0) {
         Some(cookie) => {
           assert!(cookie.options.same_site.is_some());
@@ -338,7 +338,7 @@ mod tests {
   fn it_should_execute_all_middlware_with_a_given_request_with_params() {
     let mut app = App::<Request, BasicContext>::new_basic();
 
-    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<dyn Future<Item=BasicContext, Error=io::Error> + Send> {
       let body = &context.params.get("id").unwrap().clone();
 
       context.body(body);
@@ -356,7 +356,7 @@ mod tests {
   fn it_should_execute_all_middlware_with_a_given_request_with_params_in_a_subapp() {
     let mut app1 = App::<Request, BasicContext>::new_basic();
 
-    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<dyn Future<Item=BasicContext, Error=io::Error> + Send> {
       let body = &context.params.get("id").unwrap().clone();
 
       context.body(body);
@@ -377,7 +377,7 @@ mod tests {
   fn it_should_correctly_parse_params_in_subapps() {
     let mut app1 = App::<Request, BasicContext>::new_basic();
 
-    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<dyn Future<Item=BasicContext, Error=io::Error> + Send> {
       let body = &context.params.get("id").unwrap().clone();
 
       context.body(body);
@@ -470,14 +470,14 @@ mod tests {
   fn it_should_execute_all_middlware_with_a_given_request_based_on_method() {
     let mut app = App::<Request, BasicContext>::new_basic();
 
-    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<dyn Future<Item=BasicContext, Error=io::Error> + Send> {
       let existing_body = context.get_body().clone();
 
       context.body(&format!("{}{}", existing_body, "1"));
       Box::new(future::ok(context))
     };
 
-    fn test_fn_2(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_fn_2(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<dyn Future<Item=BasicContext, Error=io::Error> + Send> {
       let existing_body = context.get_body().clone();
 
       context.body(&format!("{}{}", existing_body, "2"));
@@ -496,14 +496,14 @@ mod tests {
   fn it_should_execute_all_middlware_with_a_given_request_up_and_down() {
     let mut app = App::<Request, BasicContext>::new_basic();
 
-    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<dyn Future<Item=BasicContext, Error=io::Error> + Send> {
       let existing_body = context.get_body().clone();
 
       context.body(&format!("{}{}", existing_body, "1"));
       Box::new(future::ok(context))
     };
 
-    fn test_fn_2(mut context: BasicContext, next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_fn_2(mut context: BasicContext, next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<dyn Future<Item=BasicContext, Error=io::Error> + Send> {
       let existing_body = context.get_body().clone();
 
       context.body(&format!("{}{}", existing_body, "2"));
@@ -530,7 +530,7 @@ mod tests {
   fn it_should_return_whatever_was_set_as_the_body_of_the_context() {
     let mut app = App::<Request, BasicContext>::new_basic();
 
-    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<dyn Future<Item=BasicContext, Error=io::Error> + Send> {
       context.body("Hello world");
       Box::new(future::ok(context))
     };
@@ -546,7 +546,7 @@ mod tests {
   fn it_should_first_run_use_then_methods() {
     let mut app = App::<Request, BasicContext>::new_basic();
 
-    fn method_agnostic(mut context: BasicContext, next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn method_agnostic(mut context: BasicContext, next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<dyn Future<Item=BasicContext, Error=io::Error> + Send> {
       context.body("agnostic");
       let updated_context = next(context);
 
@@ -558,7 +558,7 @@ mod tests {
       Box::new(body_with_copied_context)
     }
 
-    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<dyn Future<Item=BasicContext, Error=io::Error> + Send> {
       let body = context.get_body().clone();
 
       context.body(&format!("{}-1", body));
@@ -577,7 +577,7 @@ mod tests {
   fn it_should_be_able_to_correctly_route_sub_apps() {
     let mut app1 = App::<Request, BasicContext>::new_basic();
 
-    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<dyn Future<Item=BasicContext, Error=io::Error> + Send> {
       context.body("1");
       Box::new(future::ok(context))
     };
@@ -596,7 +596,7 @@ mod tests {
   fn it_should_be_able_to_correctly_route_sub_apps_with_wildcards() {
     let mut app1 = App::<Request, BasicContext>::new_basic();
 
-    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<dyn Future<Item=BasicContext, Error=io::Error> + Send> {
       context.body("1");
       Box::new(future::ok(context))
     };
@@ -615,7 +615,7 @@ mod tests {
   fn it_should_be_able_to_correctly_prefix_route_sub_apps() {
     let mut app1 = App::<Request, BasicContext>::new_basic();
 
-    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<dyn Future<Item=BasicContext, Error=io::Error> + Send> {
       context.body("1");
       Box::new(future::ok(context))
     };
@@ -634,7 +634,7 @@ mod tests {
   fn it_should_be_able_to_correctly_prefix_the_root_of_sub_apps() {
     let mut app1 = App::<Request, BasicContext>::new_basic();
 
-    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<dyn Future<Item=BasicContext, Error=io::Error> + Send> {
       context.body("1");
       Box::new(future::ok(context))
     };
@@ -653,12 +653,12 @@ mod tests {
   fn it_should_be_able_to_correctly_handle_not_found_routes() {
     let mut app = App::<Request, BasicContext>::new_basic();
 
-    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<dyn Future<Item=BasicContext, Error=io::Error> + Send> {
       context.body("1");
       Box::new(future::ok(context))
     };
 
-    fn test_404(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_404(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<dyn Future<Item=BasicContext, Error=io::Error> + Send> {
       context.body("not found");
       Box::new(future::ok(context))
     };
@@ -676,12 +676,12 @@ mod tests {
   fn it_should_be_able_to_correctly_handle_not_found_at_the_root() {
     let mut app = App::<Request, BasicContext>::new_basic();
 
-    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<dyn Future<Item=BasicContext, Error=io::Error> + Send> {
       context.body("1");
       Box::new(future::ok(context))
     };
 
-    fn test_404(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_404(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<dyn Future<Item=BasicContext, Error=io::Error> + Send> {
       context.body("not found");
       Box::new(future::ok(context))
     };
@@ -698,12 +698,12 @@ mod tests {
   fn it_should_be_able_to_correctly_handle_deep_not_found_routes() {
     let mut app = App::<Request, BasicContext>::new_basic();
 
-    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<dyn Future<Item=BasicContext, Error=io::Error> + Send> {
       context.body("1");
       Box::new(future::ok(context))
     };
 
-    fn test_404(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_404(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<dyn Future<Item=BasicContext, Error=io::Error> + Send> {
       context.body("not found");
       Box::new(future::ok(context))
     };
@@ -720,12 +720,12 @@ mod tests {
   fn it_should_be_able_to_correctly_handle_deep_not_found_routes_after_paramaterized_routes() {
     let mut app = App::<Request, BasicContext>::new_basic();
 
-    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<dyn Future<Item=BasicContext, Error=io::Error> + Send> {
       context.body("1");
       Box::new(future::ok(context))
     };
 
-    fn test_404(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_404(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<dyn Future<Item=BasicContext, Error=io::Error> + Send> {
       context.body("not found");
       Box::new(future::ok(context))
     };
@@ -742,12 +742,12 @@ mod tests {
   fn it_should_be_able_to_correctly_handle_deep_not_found_routes_after_paramaterized_routes_with_extra_pieces() {
     let mut app = App::<Request, BasicContext>::new_basic();
 
-    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<dyn Future<Item=BasicContext, Error=io::Error> + Send> {
       context.body("1");
       Box::new(future::ok(context))
     };
 
-    fn test_404(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_404(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<dyn Future<Item=BasicContext, Error=io::Error> + Send> {
       context.body("not found");
       Box::new(future::ok(context))
     };
@@ -766,12 +766,12 @@ mod tests {
     let mut app2 = App::<Request, BasicContext>::new_basic();
     let mut app3 = App::<Request, BasicContext>::new_basic();
 
-    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<dyn Future<Item=BasicContext, Error=io::Error> + Send> {
       context.body("1");
       Box::new(future::ok(context))
     };
 
-    fn test_404(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_404(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<dyn Future<Item=BasicContext, Error=io::Error> + Send> {
       context.body("not found");
       Box::new(future::ok(context))
     };
@@ -790,7 +790,7 @@ mod tests {
   fn it_should_handle_routes_without_leading_slash() {
     let mut app = App::<Request, BasicContext>::new_basic();
 
-    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<dyn Future<Item=BasicContext, Error=io::Error> + Send> {
       context.body("1");
       Box::new(future::ok(context))
     };
@@ -807,7 +807,7 @@ mod tests {
     let mut app1 = App::<Request, BasicContext>::new_basic();
     let mut app2 = App::<Request, BasicContext>::new_basic();
 
-    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<dyn Future<Item=BasicContext, Error=io::Error> + Send> {
       context.body("1");
       Box::new(future::ok(context))
     };
@@ -826,12 +826,12 @@ mod tests {
     let mut app2 = App::<Request, BasicContext>::new_basic();
     let mut app3 = App::<Request, BasicContext>::new_basic();
 
-    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<dyn Future<Item=BasicContext, Error=io::Error> + Send> {
       context.body("1");
       Box::new(future::ok(context))
     };
 
-    fn test_fn_2(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<Future<Item=BasicContext, Error=io::Error> + Send> {
+    fn test_fn_2(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> Box<dyn Future<Item=BasicContext, Error=io::Error> + Send> {
       context.body("2");
       Box::new(future::ok(context))
     };

--- a/thruster-app/src/app.rs
+++ b/thruster-app/src/app.rs
@@ -1,6 +1,8 @@
 use std::io;
 
+#[cfg(not(feature = "thruster_async_await"))]
 use futures::future;
+
 use futures::{Future as FutureLegacy};
 use thruster_core::context::Context;
 use thruster_core::request::{Request, RequestWithParams};
@@ -239,12 +241,13 @@ mod tests {
   use std::marker::Send;
 
   use thruster_core::request::Request;
-
   use thruster_core::middleware::{MiddlewareChain, MiddlewareReturnValue};
-
   use thruster_middleware::query_params;
   use thruster_middleware::cookies;
   use thruster_context::basic_context::BasicContext;
+
+  #[cfg(feature = "thruster_async_await")]
+  use thruster_proc::{async_middleware, middleware_fn};
 
   #[test]
   fn it_should_execute_all_middlware_with_a_given_request() {

--- a/thruster-core-async-await/src/middleware.rs
+++ b/thruster-core-async-await/src/middleware.rs
@@ -6,20 +6,20 @@ use crate::errors::ThrusterError;
 #[cfg(not(feature = "thruster_error_handling"))]
 pub type MiddlewareResult<C> = C;
 #[cfg(not(feature = "thruster_error_handling"))]
-pub type MiddlewareReturnValue<T> = Pin<Box<Future<Output=T> + Send + Sync>>;
+pub type MiddlewareReturnValue<T> = Pin<Box<dyn Future<Output=T> + Send + Sync>>;
 #[cfg(not(feature = "thruster_error_handling"))]
-pub type MiddlewareNext<C> = Box<Fn(C) -> Pin<Box<Future<Output=C> + Send + Sync>> + Send + Sync>;
+pub type MiddlewareNext<C> = Box<dyn Fn(C) -> Pin<Box<dyn Future<Output=C> + Send + Sync>> + Send + Sync>;
 #[cfg(not(feature = "thruster_error_handling"))]
-type MiddlewareFn<C> = fn(C, Box<((Fn(C) -> Pin<Box<Future<Output=C> + Send + Sync>>) + 'static + Send + Sync)>) -> Pin<Box<Future<Output=C> + Send + Sync>>;
+type MiddlewareFn<C> = fn(C, Box<((Fn(C) -> Pin<Box<dyn Future<Output=C> + Send + Sync>>) + 'static + Send + Sync)>) -> Pin<Box<dyn Future<Output=C> + Send + Sync>>;
 
 #[cfg(feature = "thruster_error_handling")]
 pub type MiddlewareResult<C> = Result<C, ThrusterError<C>>;
 #[cfg(feature = "thruster_error_handling")]
-pub type MiddlewareReturnValue<C> = Pin<Box<Future<Output=MiddlewareResult<C>> + Send + Sync>>;
+pub type MiddlewareReturnValue<C> = Pin<Box<dyn Future<Output=MiddlewareResult<C>> + Send + Sync>>;
 #[cfg(feature = "thruster_error_handling")]
-pub type MiddlewareNext<C> = Box<Fn(C) -> Pin<Box<Future<Output=MiddlewareResult<C>> + Send + Sync>> + Send + Sync>;
+pub type MiddlewareNext<C> = Box<dyn Fn(C) -> Pin<Box<dyn Future<Output=MiddlewareResult<C>> + Send + Sync>> + Send + Sync>;
 #[cfg(feature = "thruster_error_handling")]
-type MiddlewareFn<C> = fn(C, Box<((Fn(C) -> Pin<Box<Future<Output=MiddlewareResult<C>> + Send + Sync>>) + 'static + Send + Sync)>) -> Pin<Box<Future<Output=MiddlewareResult<C>> + Send + Sync>>;
+type MiddlewareFn<C> = fn(C, Box<((Fn(C) -> Pin<Box<dyn Future<Output=MiddlewareResult<C>> + Send + Sync>>) + 'static + Send + Sync)>) -> Pin<Box<dyn Future<Output=MiddlewareResult<C>> + Send + Sync>>;
 
 pub struct Middleware<C: 'static> {
   pub middleware: &'static [
@@ -54,7 +54,7 @@ impl<C: 'static> Chain<C> {
     }
   }
 
-  fn chained_run(&self, i: usize, j: usize) -> Box<Fn(C) -> Pin<Box<Future<Output=MiddlewareResult<C>> + Send + Sync>> + Send + Sync> {
+  fn chained_run(&self, i: usize, j: usize) -> Box<dyn Fn(C) -> Pin<Box<dyn Future<Output=MiddlewareResult<C>> + Send + Sync>> + Send + Sync> {
     chained_run(i, j, self.nodes.clone())
   }
 
@@ -62,7 +62,7 @@ impl<C: 'static> Chain<C> {
     self.built = self.chained_run(0, 0);
   }
 
-  fn run(&self, context: C) -> Pin<Box<Future<Output=MiddlewareResult<C>> + Send + Sync>> {
+  fn run(&self, context: C) -> Pin<Box<dyn Future<Output=MiddlewareResult<C>> + Send + Sync>> {
     (self.built)(context)
   }
 }
@@ -112,12 +112,12 @@ impl<T: 'static> MiddlewareChain<T> {
   /// Run the middleware chain once
   ///
   #[cfg(not(feature = "thruster_error_handling"))]
-  pub fn run(&self, context: T) -> Pin<Box<Future<Output=T> + Send + Sync>> {
+  pub fn run(&self, context: T) -> Pin<Box<dyn Future<Output=T> + Send + Sync>> {
     self.chain.run(context)
   }
 
   #[cfg(feature = "thruster_error_handling")]
-  pub fn run(&self, context: T) -> Pin<Box<Future<Output=MiddlewareResult<T>> + Send + Sync>> {
+  pub fn run(&self, context: T) -> Pin<Box<dyn Future<Output=MiddlewareResult<T>> + Send + Sync>> {
     self.chain.run(context)
   }
 

--- a/thruster-core-async-await/src/middleware.rs
+++ b/thruster-core-async-await/src/middleware.rs
@@ -42,7 +42,7 @@ fn chained_run<C: 'static>(i: usize, j: usize, nodes: Vec<&'static Middleware<C>
 }
 
 pub struct Chain<C: 'static> {
-  nodes: Vec<&'static Middleware<C>>,
+  pub nodes: Vec<&'static Middleware<C>>,
   built: MiddlewareNext<C>
 }
 

--- a/thruster-core/src/middleware.rs
+++ b/thruster-core/src/middleware.rs
@@ -3,9 +3,9 @@ use std::sync::Arc;
 use futures::Future;
 use std::io;
 
-pub type MiddlewareReturnValue<T> = Box<Future<Item=T, Error=io::Error> + Send>;
+pub type MiddlewareReturnValue<T> = Box<dyn Future<Item=T, Error=io::Error> + Send>;
 pub type Middleware<T, M> = fn(T, next: M) -> MiddlewareReturnValue<T>;
-pub type Runnable<T> = Box<Fn(T, &Option<Box<MiddlewareChain<T>>>) -> MiddlewareReturnValue<T> + Send + Sync>;
+pub type Runnable<T> = Box<dyn Fn(T, &Option<Box<MiddlewareChain<T>>>) -> MiddlewareReturnValue<T> + Send + Sync>;
 
 ///
 /// The MiddlewareChain is used to wrap a series of middleware functions in such a way that the tail can

--- a/thruster-core/src/route_parser.rs
+++ b/thruster-core/src/route_parser.rs
@@ -37,10 +37,12 @@ impl<T: Context + Send> RouteParser<T> {
   }
 
   pub fn optimize(&mut self) {
-    let routes = self.route_tree.root_node.enumerate();
+    let routes = self.route_tree.root_node.get_route_list();
 
-    for (path, middleware) in routes {
-      self.shortcuts.insert((&path[1..]).to_owned(), middleware);
+    for (path, middleware, is_terminal_node) in routes {
+      if is_terminal_node {
+        self.shortcuts.insert((&path[1..]).to_owned(), middleware);
+      }
     }
   }
 

--- a/thruster/Cargo.toml
+++ b/thruster/Cargo.toml
@@ -31,6 +31,11 @@ required-features = ["thruster_async_await", "thruster_error_handling"]
 name = "app"
 harness = false
 
+[[test]]
+name = "integration"
+path = "src/integration_tests.rs"
+required-features = ["thruster_async_await"]
+
 [features]
 default = ["hyper_server"]
 hyper_server = [

--- a/thruster/Cargo.toml
+++ b/thruster/Cargo.toml
@@ -34,7 +34,6 @@ harness = false
 [[test]]
 name = "integration"
 path = "src/integration_tests.rs"
-required-features = ["thruster_async_await"]
 
 [features]
 default = ["hyper_server"]

--- a/thruster/examples/hello_world/context.rs
+++ b/thruster/examples/hello_world/context.rs
@@ -35,6 +35,10 @@ impl Ctx {
   pub fn set_header(&mut self, key: &str, val: &str) {
     self.response.header(key, val);
   }
+
+  pub fn set(&mut self, key: &str, value: &str) {
+    self.headers.push((key.to_owned(), value.to_owned()));
+  }
 }
 
 impl Context for Ctx {

--- a/thruster/examples/hyper_most_basic.rs
+++ b/thruster/examples/hyper_most_basic.rs
@@ -1,12 +1,13 @@
 #[macro_use] extern crate thruster;
-extern crate futures_legacy;
+extern crate futures;
 extern crate hyper;
 
 use std::boxed::Box;
-use futures_legacy::future;
+use futures::future;
 
-use thruster::{App, Context, MiddlewareChain, MiddlewareReturnValue};
-use thruster::server::{HyperServer, ThrusterServer};
+use thruster::{App, Context, MiddlewareChain, MiddlewareReturnValue, ThrusterServer};
+use thruster::server::{Server};
+use thruster::hyper_server::{HyperServer};
 use thruster::thruster_context::basic_hyper_context::{generate_context, BasicHyperContext as Ctx, HyperRequest};
 
 fn plaintext(mut context: Ctx, _next: impl Fn(Ctx) -> MiddlewareReturnValue<Ctx>  + Send + Sync) -> MiddlewareReturnValue<Ctx> {
@@ -23,6 +24,6 @@ fn main() {
 
   app.get("/plaintext", middleware![Ctx => plaintext]);
 
-  let server = Server::new(app);
+  let server = HyperServer::new(app);
   server.start("0.0.0.0", 4321);
 }

--- a/thruster/examples/most_basic_async.rs
+++ b/thruster/examples/most_basic_async.rs
@@ -30,13 +30,20 @@ async fn plaintext(mut context: Ctx, _next: MiddlewareNext<Ctx>) -> Ctx {
   context
 }
 
+#[middleware_fn]
+async fn test_fn_404(mut context: Ctx, _next: MiddlewareNext<Ctx>) -> Ctx {
+  context.body("404");
+  context
+}
+
 fn main() {
   println!("Starting server...");
 
   let mut app = App::<Request, Ctx>::new_basic();
 
-  app.use_middleware("/", async_middleware!(Ctx, [profiling]));
-  app.get("/plaintext", async_middleware!(Ctx, [plaintext]));
+  // app.use_middleware("/", async_middleware!(Ctx, [profiling]));
+  app.get("/plaintext/:asd", async_middleware!(Ctx, [plaintext]));
+  app.set404(async_middleware!(Ctx, [test_fn_404]));
 
   let server = Server::new(app);
   server.start("0.0.0.0", 4321);

--- a/thruster/src/integration_tests.rs
+++ b/thruster/src/integration_tests.rs
@@ -1,32 +1,32 @@
-#![feature(async_await, proc_macro_hygiene)]
+use std::boxed::Box;
+use futures::future;
 
-use thruster::{MiddlewareNext, MiddlewareReturnValue, Request};
-use thruster::{App, BasicContext};
-use thruster::thruster_proc::{async_middleware, middleware_fn};
+use thruster::{App, BasicContext as Ctx, MiddlewareChain, MiddlewareReturnValue, Request};
+use thruster_core::{middleware};
 use thruster::testing;
 
-#[middleware_fn]
-async fn test_fn_1(mut context: BasicContext, _next: MiddlewareNext<BasicContext>) -> BasicContext {
+
+fn test_fn_1(mut context: Ctx, _next: impl Fn(Ctx) -> MiddlewareReturnValue<Ctx>  + Send + Sync) -> MiddlewareReturnValue<Ctx> {
   let body = &context.params.get("id").unwrap().clone();
 
   context.body(body);
-  context
+
+  Box::new(future::ok(context))
 }
 
-#[middleware_fn]
-async fn test_fn_404(mut context: BasicContext, _next: MiddlewareNext<BasicContext>) -> BasicContext {
+fn test_fn_404(mut context: Ctx, _next: impl Fn(Ctx) -> MiddlewareReturnValue<Ctx>  + Send + Sync) -> MiddlewareReturnValue<Ctx> {
   context.body("404");
-  context
+
+  Box::new(future::ok(context))
 }
+
 
 #[test]
 fn it_should_correctly_404_if_no_param_is_given() {
-  let mut app = App::<Request, BasicContext>::new_basic();
+  let mut app = App::<Request, Ctx>::new_basic();
 
-  app.get("/test/:id", async_middleware!(BasicContext, [test_fn_1]));
-  app.get("/a", async_middleware!(BasicContext, [test_fn_1]));
-  app.get("/a/b/c", async_middleware!(BasicContext, [test_fn_1]));
-  app.set404(async_middleware!(BasicContext, [test_fn_404]));
+  app.get("/test/:id", middleware![Ctx => test_fn_1]);
+  app.set404(middleware![Ctx => test_fn_404]);
   app._route_parser.optimize();
 
   let response = testing::get(&app, "/test");

--- a/thruster/src/integration_tests.rs
+++ b/thruster/src/integration_tests.rs
@@ -1,0 +1,35 @@
+#![feature(async_await, proc_macro_hygiene)]
+
+use thruster::{MiddlewareNext, MiddlewareReturnValue, Request};
+use thruster::{App, BasicContext};
+use thruster::thruster_proc::{async_middleware, middleware_fn};
+use thruster::testing;
+
+#[middleware_fn]
+async fn test_fn_1(mut context: BasicContext, _next: MiddlewareNext<BasicContext>) -> BasicContext {
+  let body = &context.params.get("id").unwrap().clone();
+
+  context.body(body);
+  context
+}
+
+#[middleware_fn]
+async fn test_fn_404(mut context: BasicContext, _next: MiddlewareNext<BasicContext>) -> BasicContext {
+  context.body("404");
+  context
+}
+
+#[test]
+fn it_should_correctly_404_if_no_param_is_given() {
+  let mut app = App::<Request, BasicContext>::new_basic();
+
+  app.get("/test/:id", async_middleware!(BasicContext, [test_fn_1]));
+  app.get("/a", async_middleware!(BasicContext, [test_fn_1]));
+  app.get("/a/b/c", async_middleware!(BasicContext, [test_fn_1]));
+  app.set404(async_middleware!(BasicContext, [test_fn_404]));
+  app._route_parser.optimize();
+
+  let response = testing::get(&app, "/test");
+
+  assert!(response.body == "404");
+}


### PR DESCRIPTION
**Issue:** If you have a route such as `/test/:id`, then curling `/test` will cause an end of cycle error.

**Solution:** This was happening, and wasn't caught by our tests, because of the optimization hash that we use to short circuit the route tree. Now we'll make sure that the route is a terminal non-wildcard route before adding it to the optimized tree. Also updated the enumerate method for nodes to return more useful information.

Should resolve #116 