### PR TITLE
bug: Remove extra Vec -> Slice -> Vec step

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ use thruster::{App, BasicContext as Ctx, MiddlewareChain, MiddlewareReturnValue,
 use thruster::builtins::server::Server;
 use thruster::server::ThrusterServer;
 
-fn plaintext(mut context: Ctx, next: impl Fn(Ctx) -> MiddlewareReturnValue<Ctx>  + Send + Sync) -> MiddlewareReturnValue<Ctx> {
+fn plaintext(mut context: Ctx, next: impl Fn(Ctx) -> MiddlewareReturnValue<Ctx>  + Send) -> MiddlewareReturnValue<Ctx> {
   let val = "Hello, World!".to_owned();
   context.body = val;
 
@@ -102,7 +102,7 @@ use thruster::builtins::hyper_server::Server;
 use thruster::builtins::basic_hyper_context::{generate_context, BasicHyperContext as Ctx};
 use thruster::server::ThrusterServer;
 
-fn plaintext(mut context: Ctx, next: impl Fn(Ctx) -> MiddlewareReturnValue<Ctx>  + Send + Sync) -> MiddlewareReturnValue<Ctx> {
+fn plaintext(mut context: Ctx, next: impl Fn(Ctx) -> MiddlewareReturnValue<Ctx>  + Send) -> MiddlewareReturnValue<Ctx> {
   let val = "Hello, World!".to_owned();
   context.body = val;
 

--- a/thruster-app/Cargo.toml
+++ b/thruster-app/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 debug = true
 
 [features]
-default = ["hyper_server"]
+default = []
 hyper_server = []
 thruster_async_await = [
   "thruster-core/thruster_async_await",
@@ -31,6 +31,7 @@ thruster_error_handling = [
 [dependencies]
 bytes = "0.4"
 futures = "0.1.23"
+futures-preview = { package = "futures-preview", version = "0.3.0-alpha.17", features = ["compat"] }
 templatify = "0.2.3"
 thruster-async-await = { version = "0.7", path = "../thruster-async-await", optional = true }
 thruster-context = { version = "0.7", path = "../thruster-context" }

--- a/thruster-app/src/testing.rs
+++ b/thruster-app/src/testing.rs
@@ -1,137 +1,137 @@
-// use bytes::{BytesMut, BufMut};
-// use futures::Future;
-// use std::collections::HashMap;
+use bytes::{BytesMut, BufMut};
+use futures::Future;
+use std::collections::HashMap;
 
-// use crate::app::App;
+use crate::app::App;
 
-// use thruster_core::context::Context;
-// use thruster_core::response::{Response, StatusMessage};
-// use thruster_core::request::decode;
-// use thruster_core::request::Request;
+use thruster_core::context::Context;
+use thruster_core::response::{Response, StatusMessage};
+use thruster_core::request::decode;
+use thruster_core::request::Request;
 
-// pub fn request<T: Context<Response = Response> + Send>(app: &App<Request, T>, method: &str, route: &str, headers: &[(&str, &str)], body: &str) -> TestResponse {
-//   let headers_mapped: Vec<String> = headers
-//     .iter()
-//     .map(|val| format!("{}: {}", val.0, val.1))
-//     .collect();
-//   let headers = headers_mapped
-//     .join("\n");
-//   let body = format!("{} {} HTTP/1.1\nHost: localhost:8080\n{}\n\n{}", method, route, headers, body);
+pub fn request<T: Context<Response = Response> + Send>(app: &App<Request, T>, method: &str, route: &str, headers: &[(&str, &str)], body: &str) -> TestResponse {
+  let headers_mapped: Vec<String> = headers
+    .iter()
+    .map(|val| format!("{}: {}", val.0, val.1))
+    .collect();
+  let headers = headers_mapped
+    .join("\n");
+  let body = format!("{} {} HTTP/1.1\nHost: localhost:8080\n{}\n\n{}", method, route, headers, body);
 
-//   let mut bytes = BytesMut::with_capacity(body.len());
-//   bytes.put(&body);
-
-
-//   let request = decode(&mut bytes).unwrap().unwrap();
-//   let matched_route = app.resolve_from_method_and_path("GET", route);
-//   let response = app.resolve(request, matched_route).wait().unwrap();
-
-//   TestResponse::new(response)
-// }
+  let mut bytes = BytesMut::with_capacity(body.len());
+  bytes.put(&body);
 
 
-// pub fn get<T: Context<Response = Response> + Send>(app: &App<Request, T>, route: &str) -> TestResponse {
-//   let body = format!("GET {} HTTP/1.1\nHost: localhost:8080\n\n", route);
+  let request = decode(&mut bytes).unwrap().unwrap();
+  let matched_route = app.resolve_from_method_and_path("GET", route);
+  let response = app.resolve(request, matched_route).wait().unwrap();
 
-//   let mut bytes = BytesMut::with_capacity(body.len());
-//   bytes.put(&body);
-
-
-//   let request = decode(&mut bytes).unwrap().unwrap();
-//   let matched_route = app.resolve_from_method_and_path("GET", route);
-//   let response = app.resolve(request, matched_route).wait().unwrap();
-
-//   TestResponse::new(response)
-// }
-
-// pub fn delete<T: Context<Response = Response> + Send>(app: &App<Request, T>, route: &str) -> TestResponse {
-//   let body = format!("DELETE {} HTTP/1.1\nHost: localhost:8080\n\n", route);
-
-//   let mut bytes = BytesMut::with_capacity(body.len());
-//   bytes.put(&body);
+  TestResponse::new(response)
+}
 
 
-//   let request = decode(&mut bytes).unwrap().unwrap();
-//   let matched_route = app.resolve_from_method_and_path("DELETE", route);
-//   let response = app.resolve(request, matched_route).wait().unwrap();
+pub fn get<T: Context<Response = Response> + Send>(app: &App<Request, T>, route: &str) -> TestResponse {
+  let body = format!("GET {} HTTP/1.1\nHost: localhost:8080\n\n", route);
+
+  let mut bytes = BytesMut::with_capacity(body.len());
+  bytes.put(&body);
 
 
-//   TestResponse::new(response)
-// }
+  let request = decode(&mut bytes).unwrap().unwrap();
+  let matched_route = app.resolve_from_method_and_path("GET", route);
+  let response = app.resolve(request, matched_route).wait().unwrap();
 
-// pub fn post<T: Context<Response = Response> + Send>(app: &App<Request, T>, route: &str, content: &str) -> TestResponse {
-//   let body = format!("POST {} HTTP/1.1\nHost: localhost:8080\nContent-Length: {}\n\n{}", route, content.len(), content);
+  TestResponse::new(response)
+}
 
-//   let mut bytes = BytesMut::with_capacity(body.len());
-//   bytes.put(&body);
+pub fn delete<T: Context<Response = Response> + Send>(app: &App<Request, T>, route: &str) -> TestResponse {
+  let body = format!("DELETE {} HTTP/1.1\nHost: localhost:8080\n\n", route);
 
-
-//   let request = decode(&mut bytes).unwrap().unwrap();
-//   let matched_route = app.resolve_from_method_and_path("POST", route);
-//   let response = app.resolve(request, matched_route).wait().unwrap();
-
-
-//   TestResponse::new(response)
-// }
-
-// pub fn put<T: Context<Response = Response> + Send>(app: &App<Request, T>, route: &str, content: &str) -> TestResponse {
-//   let body = format!("PUT {} HTTP/1.1\nHost: localhost:8080\nContent-Length: {}\n\n{}", route, content.len(), content);
-
-//   let mut bytes = BytesMut::with_capacity(body.len());
-//   bytes.put(&body);
+  let mut bytes = BytesMut::with_capacity(body.len());
+  bytes.put(&body);
 
 
-//   let request = decode(&mut bytes).unwrap().unwrap();
-//   let matched_route = app.resolve_from_method_and_path("PUT", route);
-//   let response = app.resolve(request, matched_route).wait().unwrap();
+  let request = decode(&mut bytes).unwrap().unwrap();
+  let matched_route = app.resolve_from_method_and_path("DELETE", route);
+  let response = app.resolve(request, matched_route).wait().unwrap();
 
 
-//   TestResponse::new(response)
-// }
+  TestResponse::new(response)
+}
 
-// pub fn update<T: Context<Response = Response> + Send>(app: &App<Request, T>, route: &str, content: &str) -> TestResponse {
-//   let body = format!("UPDATE {} HTTP/1.1\nHost: localhost:8080\nContent-Length: {}\n\n{}", route, content.len(), content);
+pub fn post<T: Context<Response = Response> + Send>(app: &App<Request, T>, route: &str, content: &str) -> TestResponse {
+  let body = format!("POST {} HTTP/1.1\nHost: localhost:8080\nContent-Length: {}\n\n{}", route, content.len(), content);
 
-//   let mut bytes = BytesMut::with_capacity(body.len());
-//   bytes.put(&body);
-
-
-//   let request = decode(&mut bytes).unwrap().unwrap();
-//   let matched_route = app.resolve_from_method_and_path("UPDATE", route);
-//   let response = app.resolve(request, matched_route).wait().unwrap();
+  let mut bytes = BytesMut::with_capacity(body.len());
+  bytes.put(&body);
 
 
-//   TestResponse::new(response)
-// }
+  let request = decode(&mut bytes).unwrap().unwrap();
+  let matched_route = app.resolve_from_method_and_path("POST", route);
+  let response = app.resolve(request, matched_route).wait().unwrap();
 
-// pub struct TestResponse {
-//   pub body: String,
-//   pub headers: HashMap<String, String>,
-//   pub status: (String, u32)
-// }
 
-// impl TestResponse {
-//   fn new(response: Response) -> TestResponse {
-//     let mut headers = HashMap::new();
-//     let header_string = String::from_utf8(response.header_raw.to_vec()).unwrap();
+  TestResponse::new(response)
+}
 
-//     for header_pair in header_string.split("\r\n") {
-//       if !header_pair.is_empty() {
-//         let mut split = header_pair.split(':');
-//         let key = split.next().unwrap().trim().to_owned();
-//         let value = split.next().unwrap().trim().to_owned();
+pub fn put<T: Context<Response = Response> + Send>(app: &App<Request, T>, route: &str, content: &str) -> TestResponse {
+  let body = format!("PUT {} HTTP/1.1\nHost: localhost:8080\nContent-Length: {}\n\n{}", route, content.len(), content);
 
-//         headers.insert(key, value);
-//       }
-//     }
+  let mut bytes = BytesMut::with_capacity(body.len());
+  bytes.put(&body);
 
-//     TestResponse {
-//       body: String::from_utf8(response.response).unwrap(),
-//       headers,
-//       status: match response.status_message {
-//         StatusMessage::Ok => ("Ok".to_owned(), 200),
-//         StatusMessage::Custom(code, message) => (message, code)
-//       }
-//     }
-//   }
-// }
+
+  let request = decode(&mut bytes).unwrap().unwrap();
+  let matched_route = app.resolve_from_method_and_path("PUT", route);
+  let response = app.resolve(request, matched_route).wait().unwrap();
+
+
+  TestResponse::new(response)
+}
+
+pub fn update<T: Context<Response = Response> + Send>(app: &App<Request, T>, route: &str, content: &str) -> TestResponse {
+  let body = format!("UPDATE {} HTTP/1.1\nHost: localhost:8080\nContent-Length: {}\n\n{}", route, content.len(), content);
+
+  let mut bytes = BytesMut::with_capacity(body.len());
+  bytes.put(&body);
+
+
+  let request = decode(&mut bytes).unwrap().unwrap();
+  let matched_route = app.resolve_from_method_and_path("UPDATE", route);
+  let response = app.resolve(request, matched_route).wait().unwrap();
+
+
+  TestResponse::new(response)
+}
+
+pub struct TestResponse {
+  pub body: String,
+  pub headers: HashMap<String, String>,
+  pub status: (String, u32)
+}
+
+impl TestResponse {
+  fn new(response: Response) -> TestResponse {
+    let mut headers = HashMap::new();
+    let header_string = String::from_utf8(response.header_raw.to_vec()).unwrap();
+
+    for header_pair in header_string.split("\r\n") {
+      if !header_pair.is_empty() {
+        let mut split = header_pair.split(':');
+        let key = split.next().unwrap().trim().to_owned();
+        let value = split.next().unwrap().trim().to_owned();
+
+        headers.insert(key, value);
+      }
+    }
+
+    TestResponse {
+      body: String::from_utf8(response.response).unwrap(),
+      headers,
+      status: match response.status_message {
+        StatusMessage::Ok => ("Ok".to_owned(), 200),
+        StatusMessage::Custom(code, message) => (message, code)
+      }
+    }
+  }
+}

--- a/thruster-app/src/testing.rs
+++ b/thruster-app/src/testing.rs
@@ -1,137 +1,137 @@
-use bytes::{BytesMut, BufMut};
-use futures::Future;
-use std::collections::HashMap;
+// use bytes::{BytesMut, BufMut};
+// use futures::Future;
+// use std::collections::HashMap;
 
-use crate::app::App;
+// use crate::app::App;
 
-use thruster_core::context::Context;
-use thruster_core::response::{Response, StatusMessage};
-use thruster_core::request::decode;
-use thruster_core::request::Request;
+// use thruster_core::context::Context;
+// use thruster_core::response::{Response, StatusMessage};
+// use thruster_core::request::decode;
+// use thruster_core::request::Request;
 
-pub fn request<T: Context<Response = Response> + Send>(app: &App<Request, T>, method: &str, route: &str, headers: &[(&str, &str)], body: &str) -> TestResponse {
-  let headers_mapped: Vec<String> = headers
-    .iter()
-    .map(|val| format!("{}: {}", val.0, val.1))
-    .collect();
-  let headers = headers_mapped
-    .join("\n");
-  let body = format!("{} {} HTTP/1.1\nHost: localhost:8080\n{}\n\n{}", method, route, headers, body);
+// pub fn request<T: Context<Response = Response> + Send>(app: &App<Request, T>, method: &str, route: &str, headers: &[(&str, &str)], body: &str) -> TestResponse {
+//   let headers_mapped: Vec<String> = headers
+//     .iter()
+//     .map(|val| format!("{}: {}", val.0, val.1))
+//     .collect();
+//   let headers = headers_mapped
+//     .join("\n");
+//   let body = format!("{} {} HTTP/1.1\nHost: localhost:8080\n{}\n\n{}", method, route, headers, body);
 
-  let mut bytes = BytesMut::with_capacity(body.len());
-  bytes.put(&body);
-
-
-  let request = decode(&mut bytes).unwrap().unwrap();
-  let matched_route = app.resolve_from_method_and_path("GET", route);
-  let response = app.resolve(request, matched_route).wait().unwrap();
-
-  TestResponse::new(response)
-}
+//   let mut bytes = BytesMut::with_capacity(body.len());
+//   bytes.put(&body);
 
 
-pub fn get<T: Context<Response = Response> + Send>(app: &App<Request, T>, route: &str) -> TestResponse {
-  let body = format!("GET {} HTTP/1.1\nHost: localhost:8080\n\n", route);
+//   let request = decode(&mut bytes).unwrap().unwrap();
+//   let matched_route = app.resolve_from_method_and_path("GET", route);
+//   let response = app.resolve(request, matched_route).wait().unwrap();
 
-  let mut bytes = BytesMut::with_capacity(body.len());
-  bytes.put(&body);
-
-
-  let request = decode(&mut bytes).unwrap().unwrap();
-  let matched_route = app.resolve_from_method_and_path("GET", route);
-  let response = app.resolve(request, matched_route).wait().unwrap();
-
-  TestResponse::new(response)
-}
-
-pub fn delete<T: Context<Response = Response> + Send>(app: &App<Request, T>, route: &str) -> TestResponse {
-  let body = format!("DELETE {} HTTP/1.1\nHost: localhost:8080\n\n", route);
-
-  let mut bytes = BytesMut::with_capacity(body.len());
-  bytes.put(&body);
+//   TestResponse::new(response)
+// }
 
 
-  let request = decode(&mut bytes).unwrap().unwrap();
-  let matched_route = app.resolve_from_method_and_path("DELETE", route);
-  let response = app.resolve(request, matched_route).wait().unwrap();
+// pub fn get<T: Context<Response = Response> + Send>(app: &App<Request, T>, route: &str) -> TestResponse {
+//   let body = format!("GET {} HTTP/1.1\nHost: localhost:8080\n\n", route);
+
+//   let mut bytes = BytesMut::with_capacity(body.len());
+//   bytes.put(&body);
 
 
-  TestResponse::new(response)
-}
+//   let request = decode(&mut bytes).unwrap().unwrap();
+//   let matched_route = app.resolve_from_method_and_path("GET", route);
+//   let response = app.resolve(request, matched_route).wait().unwrap();
 
-pub fn post<T: Context<Response = Response> + Send>(app: &App<Request, T>, route: &str, content: &str) -> TestResponse {
-  let body = format!("POST {} HTTP/1.1\nHost: localhost:8080\nContent-Length: {}\n\n{}", route, content.len(), content);
+//   TestResponse::new(response)
+// }
 
-  let mut bytes = BytesMut::with_capacity(body.len());
-  bytes.put(&body);
+// pub fn delete<T: Context<Response = Response> + Send>(app: &App<Request, T>, route: &str) -> TestResponse {
+//   let body = format!("DELETE {} HTTP/1.1\nHost: localhost:8080\n\n", route);
 
-
-  let request = decode(&mut bytes).unwrap().unwrap();
-  let matched_route = app.resolve_from_method_and_path("POST", route);
-  let response = app.resolve(request, matched_route).wait().unwrap();
-
-
-  TestResponse::new(response)
-}
-
-pub fn put<T: Context<Response = Response> + Send>(app: &App<Request, T>, route: &str, content: &str) -> TestResponse {
-  let body = format!("PUT {} HTTP/1.1\nHost: localhost:8080\nContent-Length: {}\n\n{}", route, content.len(), content);
-
-  let mut bytes = BytesMut::with_capacity(body.len());
-  bytes.put(&body);
+//   let mut bytes = BytesMut::with_capacity(body.len());
+//   bytes.put(&body);
 
 
-  let request = decode(&mut bytes).unwrap().unwrap();
-  let matched_route = app.resolve_from_method_and_path("PUT", route);
-  let response = app.resolve(request, matched_route).wait().unwrap();
+//   let request = decode(&mut bytes).unwrap().unwrap();
+//   let matched_route = app.resolve_from_method_and_path("DELETE", route);
+//   let response = app.resolve(request, matched_route).wait().unwrap();
 
 
-  TestResponse::new(response)
-}
+//   TestResponse::new(response)
+// }
 
-pub fn update<T: Context<Response = Response> + Send>(app: &App<Request, T>, route: &str, content: &str) -> TestResponse {
-  let body = format!("UPDATE {} HTTP/1.1\nHost: localhost:8080\nContent-Length: {}\n\n{}", route, content.len(), content);
+// pub fn post<T: Context<Response = Response> + Send>(app: &App<Request, T>, route: &str, content: &str) -> TestResponse {
+//   let body = format!("POST {} HTTP/1.1\nHost: localhost:8080\nContent-Length: {}\n\n{}", route, content.len(), content);
 
-  let mut bytes = BytesMut::with_capacity(body.len());
-  bytes.put(&body);
-
-
-  let request = decode(&mut bytes).unwrap().unwrap();
-  let matched_route = app.resolve_from_method_and_path("UPDATE", route);
-  let response = app.resolve(request, matched_route).wait().unwrap();
+//   let mut bytes = BytesMut::with_capacity(body.len());
+//   bytes.put(&body);
 
 
-  TestResponse::new(response)
-}
+//   let request = decode(&mut bytes).unwrap().unwrap();
+//   let matched_route = app.resolve_from_method_and_path("POST", route);
+//   let response = app.resolve(request, matched_route).wait().unwrap();
 
-pub struct TestResponse {
-  pub body: String,
-  pub headers: HashMap<String, String>,
-  pub status: (String, u32)
-}
 
-impl TestResponse {
-  fn new(response: Response) -> TestResponse {
-    let mut headers = HashMap::new();
-    let header_string = String::from_utf8(response.header_raw.to_vec()).unwrap();
+//   TestResponse::new(response)
+// }
 
-    for header_pair in header_string.split("\r\n") {
-      if !header_pair.is_empty() {
-        let mut split = header_pair.split(':');
-        let key = split.next().unwrap().trim().to_owned();
-        let value = split.next().unwrap().trim().to_owned();
+// pub fn put<T: Context<Response = Response> + Send>(app: &App<Request, T>, route: &str, content: &str) -> TestResponse {
+//   let body = format!("PUT {} HTTP/1.1\nHost: localhost:8080\nContent-Length: {}\n\n{}", route, content.len(), content);
 
-        headers.insert(key, value);
-      }
-    }
+//   let mut bytes = BytesMut::with_capacity(body.len());
+//   bytes.put(&body);
 
-    TestResponse {
-      body: String::from_utf8(response.response).unwrap(),
-      headers,
-      status: match response.status_message {
-        StatusMessage::Ok => ("Ok".to_owned(), 200),
-        StatusMessage::Custom(code, message) => (message, code)
-      }
-    }
-  }
-}
+
+//   let request = decode(&mut bytes).unwrap().unwrap();
+//   let matched_route = app.resolve_from_method_and_path("PUT", route);
+//   let response = app.resolve(request, matched_route).wait().unwrap();
+
+
+//   TestResponse::new(response)
+// }
+
+// pub fn update<T: Context<Response = Response> + Send>(app: &App<Request, T>, route: &str, content: &str) -> TestResponse {
+//   let body = format!("UPDATE {} HTTP/1.1\nHost: localhost:8080\nContent-Length: {}\n\n{}", route, content.len(), content);
+
+//   let mut bytes = BytesMut::with_capacity(body.len());
+//   bytes.put(&body);
+
+
+//   let request = decode(&mut bytes).unwrap().unwrap();
+//   let matched_route = app.resolve_from_method_and_path("UPDATE", route);
+//   let response = app.resolve(request, matched_route).wait().unwrap();
+
+
+//   TestResponse::new(response)
+// }
+
+// pub struct TestResponse {
+//   pub body: String,
+//   pub headers: HashMap<String, String>,
+//   pub status: (String, u32)
+// }
+
+// impl TestResponse {
+//   fn new(response: Response) -> TestResponse {
+//     let mut headers = HashMap::new();
+//     let header_string = String::from_utf8(response.header_raw.to_vec()).unwrap();
+
+//     for header_pair in header_string.split("\r\n") {
+//       if !header_pair.is_empty() {
+//         let mut split = header_pair.split(':');
+//         let key = split.next().unwrap().trim().to_owned();
+//         let value = split.next().unwrap().trim().to_owned();
+
+//         headers.insert(key, value);
+//       }
+//     }
+
+//     TestResponse {
+//       body: String::from_utf8(response.response).unwrap(),
+//       headers,
+//       status: match response.status_message {
+//         StatusMessage::Ok => ("Ok".to_owned(), 200),
+//         StatusMessage::Custom(code, message) => (message, code)
+//       }
+//     }
+//   }
+// }

--- a/thruster-context/Cargo.toml
+++ b/thruster-context/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/trezm/thruster"
 edition = "2018"
 
 [features]
-default = ["hyper_server"]
+default = []
 hyper_server = [
   "hyper"
 ]

--- a/thruster-context/src/basic_context.rs
+++ b/thruster-context/src/basic_context.rs
@@ -50,11 +50,11 @@ impl BasicContext {
   /// Set the body as a string
   ///
   pub fn body(&mut self, body_string: &str) {
-    self.body_bytes = body_string.as_bytes().to_vec();
+    self.response.body_bytes_from_vec(body_string.as_bytes().to_vec());
   }
 
   pub fn get_body(&self) -> String {
-    str::from_utf8(&self.body_bytes).unwrap_or("").to_owned()
+    str::from_utf8(&self.response.response).unwrap_or("").to_owned()
   }
 
   ///

--- a/thruster-context/src/basic_context.rs
+++ b/thruster-context/src/basic_context.rs
@@ -154,7 +154,7 @@ impl Context for BasicContext {
   fn get_response(self) -> Self::Response {
     let mut response = Response::new();
 
-    response.body_bytes(&self.body_bytes);
+    response.body_bytes_from_vec(self.body_bytes);
 
     for (key, val) in self.headers {
       response.header(&key, &val);

--- a/thruster-context/src/basic_context.rs
+++ b/thruster-context/src/basic_context.rs
@@ -18,7 +18,6 @@ pub fn generate_context(request: Request) -> BasicContext {
 
 #[derive(Default)]
 pub struct BasicContext {
-  body_bytes: Vec<u8>,
   response: Response,
   pub cookies: Vec<Cookie>,
   pub params: HashMap<String, String>,
@@ -31,7 +30,6 @@ pub struct BasicContext {
 impl BasicContext {
   pub fn new() -> BasicContext {
     let mut ctx = BasicContext {
-      body_bytes: Vec::new(),
       response: Response::new(),
       cookies: Vec::new(),
       params: HashMap::new(),
@@ -154,16 +152,13 @@ impl Context for BasicContext {
   type Response = Response;
 
   fn get_response(mut self) -> Self::Response {
-    self.response.body_bytes_from_vec(self.body_bytes);
-
     self.response.status_code(self.status, "");
-
 
     self.response
   }
 
   fn set_body(&mut self, body: Vec<u8>) {
-    self.body_bytes = body;
+    self.response.body_bytes_from_vec(body);
   }
 }
 

--- a/thruster-context/src/lib.rs
+++ b/thruster-context/src/lib.rs
@@ -1,4 +1,7 @@
+#[cfg(feature="hyper_server")]
 extern crate hyper;
 
 pub mod basic_context;
+
+#[cfg(feature="hyper_server")]
 pub mod basic_hyper_context;

--- a/thruster-core-async-await/src/middleware.rs
+++ b/thruster-core-async-await/src/middleware.rs
@@ -1,25 +1,26 @@
 use std::boxed::Box;
 use futures::future::Future;
 use std::pin::Pin;
+#[cfg(feature = "thruster_error_handling")]
 use crate::errors::ThrusterError;
 
 #[cfg(not(feature = "thruster_error_handling"))]
 pub type MiddlewareResult<C> = C;
 #[cfg(not(feature = "thruster_error_handling"))]
-pub type MiddlewareReturnValue<T> = Pin<Box<dyn Future<Output=T> + Send + Sync>>;
+pub type MiddlewareReturnValue<T> = Pin<Box<dyn Future<Output=T> + Send>>;
 #[cfg(not(feature = "thruster_error_handling"))]
-pub type MiddlewareNext<C> = Box<dyn Fn(C) -> Pin<Box<dyn Future<Output=C> + Send + Sync>> + Send + Sync>;
+pub type MiddlewareNext<C> = Box<dyn Fn(C) -> Pin<Box<dyn Future<Output=C> + Send>> + Send + Sync>;
 #[cfg(not(feature = "thruster_error_handling"))]
-type MiddlewareFn<C> = fn(C, Box<((Fn(C) -> Pin<Box<dyn Future<Output=C> + Send + Sync>>) + 'static + Send + Sync)>) -> Pin<Box<dyn Future<Output=C> + Send + Sync>>;
+type MiddlewareFn<C> = fn(C, MiddlewareNext<C>) -> Pin<Box<dyn Future<Output=C> + Send>>;
 
 #[cfg(feature = "thruster_error_handling")]
 pub type MiddlewareResult<C> = Result<C, ThrusterError<C>>;
 #[cfg(feature = "thruster_error_handling")]
-pub type MiddlewareReturnValue<C> = Pin<Box<dyn Future<Output=MiddlewareResult<C>> + Send + Sync>>;
+pub type MiddlewareReturnValue<C> = Pin<Box<dyn Future<Output=MiddlewareResult<C>> + Send>>;
 #[cfg(feature = "thruster_error_handling")]
-pub type MiddlewareNext<C> = Box<dyn Fn(C) -> Pin<Box<dyn Future<Output=MiddlewareResult<C>> + Send + Sync>> + Send + Sync>;
+pub type MiddlewareNext<C> = Box<dyn Fn(C) -> Pin<Box<dyn Future<Output=MiddlewareResult<C>> + Send>> + Send + Sync>;
 #[cfg(feature = "thruster_error_handling")]
-type MiddlewareFn<C> = fn(C, Box<((Fn(C) -> Pin<Box<dyn Future<Output=MiddlewareResult<C>> + Send + Sync>>) + 'static + Send + Sync)>) -> Pin<Box<dyn Future<Output=MiddlewareResult<C>> + Send + Sync>>;
+type MiddlewareFn<C> = fn(C, MiddlewareNext<C>) -> Pin<Box<dyn Future<Output=MiddlewareResult<C>> + Send>>;
 
 pub struct Middleware<C: 'static> {
   pub middleware: &'static [
@@ -54,7 +55,7 @@ impl<C: 'static> Chain<C> {
     }
   }
 
-  fn chained_run(&self, i: usize, j: usize) -> Box<dyn Fn(C) -> Pin<Box<dyn Future<Output=MiddlewareResult<C>> + Send + Sync>> + Send + Sync> {
+  fn chained_run(&self, i: usize, j: usize) -> Box<dyn Fn(C) -> Pin<Box<dyn Future<Output=MiddlewareResult<C>> + Send>> + Send + Sync> {
     chained_run(i, j, self.nodes.clone())
   }
 
@@ -62,7 +63,7 @@ impl<C: 'static> Chain<C> {
     self.built = self.chained_run(0, 0);
   }
 
-  fn run(&self, context: C) -> Pin<Box<dyn Future<Output=MiddlewareResult<C>> + Send + Sync>> {
+  fn run(&self, context: C) -> Pin<Box<dyn Future<Output=MiddlewareResult<C>> + Send>> {
     (self.built)(context)
   }
 }
@@ -112,12 +113,12 @@ impl<T: 'static> MiddlewareChain<T> {
   /// Run the middleware chain once
   ///
   #[cfg(not(feature = "thruster_error_handling"))]
-  pub fn run(&self, context: T) -> Pin<Box<dyn Future<Output=T> + Send + Sync>> {
+  pub fn run(&self, context: T) -> Pin<Box<dyn Future<Output=T> + Send>> {
     self.chain.run(context)
   }
 
   #[cfg(feature = "thruster_error_handling")]
-  pub fn run(&self, context: T) -> Pin<Box<dyn Future<Output=MiddlewareResult<T>> + Send + Sync>> {
+  pub fn run(&self, context: T) -> Pin<Box<dyn Future<Output=MiddlewareResult<T>> + Send>> {
     self.chain.run(context)
   }
 

--- a/thruster-core/src/middleware.rs
+++ b/thruster-core/src/middleware.rs
@@ -5,7 +5,7 @@ use std::io;
 
 pub type MiddlewareReturnValue<T> = Box<dyn Future<Item=T, Error=io::Error> + Send>;
 pub type Middleware<T, M> = fn(T, next: M) -> MiddlewareReturnValue<T>;
-pub type Runnable<T> = Box<dyn Fn(T, &Option<Box<MiddlewareChain<T>>>) -> MiddlewareReturnValue<T> + Send>;
+pub type Runnable<T> = Box<dyn Fn(T, &Option<Box<MiddlewareChain<T>>>) -> MiddlewareReturnValue<T> + Send + Sync>;
 
 ///
 /// The MiddlewareChain is used to wrap a series of middleware functions in such a way that the tail can

--- a/thruster-core/src/middleware.rs
+++ b/thruster-core/src/middleware.rs
@@ -5,7 +5,7 @@ use std::io;
 
 pub type MiddlewareReturnValue<T> = Box<dyn Future<Item=T, Error=io::Error> + Send>;
 pub type Middleware<T, M> = fn(T, next: M) -> MiddlewareReturnValue<T>;
-pub type Runnable<T> = Box<dyn Fn(T, &Option<Box<MiddlewareChain<T>>>) -> MiddlewareReturnValue<T> + Send + Sync>;
+pub type Runnable<T> = Box<dyn Fn(T, &Option<Box<MiddlewareChain<T>>>) -> MiddlewareReturnValue<T> + Send>;
 
 ///
 /// The MiddlewareChain is used to wrap a series of middleware functions in such a way that the tail can
@@ -131,7 +131,7 @@ macro_rules! middleware {
 
     let mut chain: MiddlewareChain<$ctx> = MiddlewareChain::new();
 
-    fn dummy(context: $ctx, next: impl Fn($ctx) -> MiddlewareReturnValue<$ctx>  + Send + Sync) -> MiddlewareReturnValue<$ctx> {
+    fn dummy(context: $ctx, next: impl Fn($ctx) -> MiddlewareReturnValue<$ctx>  + Send) -> MiddlewareReturnValue<$ctx> {
       next(context)
     }
 
@@ -154,7 +154,7 @@ macro_rules! middleware {
 
     let mut chain = MiddlewareChain::new();
 
-    fn dummy(context: $ctx, next: impl Fn($ctx) -> MiddlewareReturnValue<$ctx>  + Send + Sync) -> MiddlewareReturnValue<$ctx> {
+    fn dummy(context: $ctx, next: impl Fn($ctx) -> MiddlewareReturnValue<$ctx>  + Send) -> MiddlewareReturnValue<$ctx> {
       next(context)
     }
 

--- a/thruster-core/src/response.rs
+++ b/thruster-core/src/response.rs
@@ -49,6 +49,11 @@ impl Response {
         self.response = b.to_vec();
         self
     }
+
+    pub fn body_bytes_from_vec(&mut self, b: Vec<u8>) -> &mut Response {
+        self.response = b;
+        self
+    }
 }
 
 pub fn encode(msg: &Response, buf: &mut BytesMut) {
@@ -56,10 +61,10 @@ pub fn encode(msg: &Response, buf: &mut BytesMut) {
     let now = crate::date::now();
 
     write!(FastWrite(buf), "\
-        HTTP/1.1 {}\r\n\
-        Content-Length: {}\r\n\
-        Date: {}\r\n\
-    ", msg.status_message, length, now).unwrap();
+HTTP/1.1 {}\r\n\
+Content-Length: {}\r\n\
+Date: {}\r\n\
+", msg.status_message, length, now).unwrap();
 
     buf.extend_from_slice(&msg.header_raw);
     buf.extend_from_slice(b"\r\n");

--- a/thruster-core/src/response.rs
+++ b/thruster-core/src/response.rs
@@ -34,12 +34,6 @@ impl Response {
         self
     }
 
-    pub fn header_raw(&mut self, buf: &BytesMut) -> &mut Response {
-        self.header_raw.extend_from_slice(buf);
-
-        self
-    }
-
     pub fn body(&mut self, s: &str) -> &mut Response {
         self.response = s.as_bytes().to_vec();
         self
@@ -63,8 +57,7 @@ pub fn encode(msg: &Response, buf: &mut BytesMut) {
     write!(FastWrite(buf), "\
 HTTP/1.1 {}\r\n\
 Content-Length: {}\r\n\
-Date: {}\r\n\
-", msg.status_message, length, now).unwrap();
+Date: {}\r\n\n", msg.status_message, length, now).unwrap();
 
     buf.extend_from_slice(&msg.header_raw);
     buf.extend_from_slice(b"\r\n");

--- a/thruster-core/src/response.rs
+++ b/thruster-core/src/response.rs
@@ -1,7 +1,6 @@
 use std::fmt::{self, Write};
 
 use bytes::BytesMut;
-use std::collections::HashMap;
 
 pub struct Response {
     pub response: Vec<u8>,

--- a/thruster-core/src/response.rs
+++ b/thruster-core/src/response.rs
@@ -1,6 +1,7 @@
 use std::fmt::{self, Write};
 
 use bytes::BytesMut;
+use std::collections::HashMap;
 
 pub struct Response {
     pub response: Vec<u8>,
@@ -55,9 +56,10 @@ pub fn encode(msg: &Response, buf: &mut BytesMut) {
     let now = crate::date::now();
 
     write!(FastWrite(buf), "\
-HTTP/1.1 {}\r\n\
-Content-Length: {}\r\n\
-Date: {}\r\n\n", msg.status_message, length, now).unwrap();
+        HTTP/1.1 {}\r\n\
+        Content-Length: {}\r\n\
+        Date: {}\r\n\
+    ", msg.status_message, length, now).unwrap();
 
     buf.extend_from_slice(&msg.header_raw);
     buf.extend_from_slice(b"\r\n");

--- a/thruster-core/src/route_parser.rs
+++ b/thruster-core/src/route_parser.rs
@@ -132,7 +132,7 @@ mod tests {
     }
   }
 
-  fn fake(_: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> MiddlewareReturnValue<BasicContext> {
+  fn fake(_: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send) -> MiddlewareReturnValue<BasicContext> {
     panic!("not implemented");
   }
 
@@ -183,11 +183,11 @@ mod tests {
 
   #[test]
   fn when_adding_a_route_with_method_agnostic_middleware() {
-    fn method_agnostic(context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> MiddlewareReturnValue<BasicContext> {
+    fn method_agnostic(context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send) -> MiddlewareReturnValue<BasicContext> {
       Box::new(future::ok(context))
     }
 
-    fn test_function(context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> MiddlewareReturnValue<BasicContext> {
+    fn test_function(context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send) -> MiddlewareReturnValue<BasicContext> {
       Box::new(future::ok(context))
     }
 

--- a/thruster-core/src/route_tree/mod.rs
+++ b/thruster-core/src/route_tree/mod.rs
@@ -194,7 +194,7 @@ mod tests {
   fn it_should_match_a_simple_route() {
     let mut route_tree = RouteTree::new();
 
-    fn test_function(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> MiddlewareReturnValue<BasicContext> {
+    fn test_function(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send) -> MiddlewareReturnValue<BasicContext> {
       context.body("Hello");
 
       Box::new(future::ok(context))
@@ -214,7 +214,7 @@ mod tests {
   fn it_should_match_a_simple_route_with_a_param() {
     let mut route_tree = RouteTree::new();
 
-    fn test_function(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> MiddlewareReturnValue<BasicContext> {
+    fn test_function(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send) -> MiddlewareReturnValue<BasicContext> {
       let body = &context.params.get("key").unwrap().clone();
 
       context.body(body);
@@ -237,11 +237,11 @@ mod tests {
 
   #[test]
   fn it_should_compose_multiple_trees() {
-    fn test_function1(context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> MiddlewareReturnValue<BasicContext> {
+    fn test_function1(context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send) -> MiddlewareReturnValue<BasicContext> {
       Box::new(future::ok(context))
     }
 
-    fn test_function2(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> MiddlewareReturnValue<BasicContext> {
+    fn test_function2(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send) -> MiddlewareReturnValue<BasicContext> {
       context.body("Hello");
 
       Box::new(future::ok(context))

--- a/thruster-middleware/Cargo.toml
+++ b/thruster-middleware/Cargo.toml
@@ -12,8 +12,7 @@ repository = "https://github.com/trezm/thruster"
 edition = "2018"
 
 [features]
-# default = []
-default = ["hyper_server"]
+default = []
 hyper_server = ["hyper"]
 
 [dependencies]

--- a/thruster-middleware/src/cookies.rs
+++ b/thruster-middleware/src/cookies.rs
@@ -51,7 +51,7 @@ pub trait HasCookies {
   fn headers(&self) -> HashMap<String, String>;
 }
 
-pub fn cookies<T: 'static + Context + HasCookies + Send>(mut context: T, next: impl Fn(T) -> MiddlewareReturnValue<T>  + Send + Sync) -> MiddlewareReturnValue<T> {
+pub fn cookies<T: 'static + Context + HasCookies + Send>(mut context: T, next: impl Fn(T) -> MiddlewareReturnValue<T>  + Send) -> MiddlewareReturnValue<T> {
   let mut cookies = Vec::new();
 
   {

--- a/thruster-middleware/src/query_params.rs
+++ b/thruster-middleware/src/query_params.rs
@@ -11,7 +11,7 @@ pub trait HasQueryParams {
   fn route(&self) -> &str;
 }
 
-pub fn query_params<T: 'static + Context + HasQueryParams + Send>(mut context: T, next: impl Fn(T) -> MiddlewareReturnValue<T>  + Send + Sync) -> MiddlewareReturnValue<T> {
+pub fn query_params<T: 'static + Context + HasQueryParams + Send>(mut context: T, next: impl Fn(T) -> MiddlewareReturnValue<T>  + Send) -> MiddlewareReturnValue<T> {
   let mut query_param_hash = HashMap::new();
 
   {

--- a/thruster-server/Cargo.toml
+++ b/thruster-server/Cargo.toml
@@ -20,11 +20,11 @@ hyper_server = [
 
 [dependencies]
 futures-legacy = { version = "0.1.23", package = "futures" }
+futures-preview = { package = "futures-preview", version = "0.3.0-alpha.17", features = ["compat"] }
 hyper = { version = "0.12.25", optional = true }
 net2 = "0.2"
 num_cpus = "1.0"
-tokio = { version = "0.1.20" }
-tokio-codec = { version = "0.1.1" }
+tokio = { version = "0.1.22" }
 thruster-core = { version = "0.7", path = "../thruster-core" }
 thruster-app = { version = "0.7", path = "../thruster-app" }
 thruster-context = { version = "0.7", path = "../thruster-context" }

--- a/thruster-server/src/lib.rs
+++ b/thruster-server/src/lib.rs
@@ -1,5 +1,7 @@
-pub mod server;
 pub mod thruster_server;
+
+#[cfg(not(feature="hyper_server"))]
+pub mod server;
 
 #[cfg(feature="hyper_server")]
 pub mod hyper_server;

--- a/thruster-server/src/server.rs
+++ b/thruster-server/src/server.rs
@@ -4,7 +4,7 @@ use futures_legacy::future;
 use tokio;
 use tokio::net::{TcpStream, TcpListener};
 use tokio::prelude::*;
-use tokio_codec::Framed;
+use tokio::codec::Framed;
 use num_cpus;
 use net2::TcpBuilder;
 #[cfg(not(windows))]

--- a/thruster/Cargo.toml
+++ b/thruster/Cargo.toml
@@ -27,6 +27,14 @@ required-features = ["thruster_async_await", "thruster_error_handling"]
 name = "errors_async"
 required-features = ["thruster_async_await", "thruster_error_handling"]
 
+[[example]]
+name = "hyper_most_basic_async"
+required-features = ["thruster_async_await", "hyper_server"]
+
+[[example]]
+name = "hyper_most_basic"
+required-features = ["hyper_server"]
+
 [[bench]]
 name = "app"
 harness = false

--- a/thruster/Cargo.toml
+++ b/thruster/Cargo.toml
@@ -36,9 +36,10 @@ name = "integration"
 path = "src/integration_tests.rs"
 
 [features]
-default = ["hyper_server"]
+default = []
 hyper_server = [
   "hyper",
+  "thruster-app/hyper_server",
   "thruster-server/hyper_server"
 ]
 thruster_async_await = [

--- a/thruster/Cargo.toml
+++ b/thruster/Cargo.toml
@@ -63,6 +63,8 @@ thruster-proc = { version = "0.7", path = "../thruster-proc", optional = true }
 thruster-server = { version = "0.7", path = "../thruster-server" }
 
 [dev-dependencies]
+bytes = "0.4"
+criterion = "0.2.11"
 diesel = { version = "1.3", features = ["postgres", "r2d2"] }
 dotenv = "0.13.0"
 lazy_static = "1.1.0"

--- a/thruster/benches/app.rs
+++ b/thruster/benches/app.rs
@@ -56,7 +56,7 @@ fn bench_route_match(c: &mut Criterion) {
   c.bench_function("Route match", |bench| {
     let mut app = App::<Request, BasicContext>::new_basic();
 
-    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> MiddlewareReturnValue<BasicContext> {
+    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send) -> MiddlewareReturnValue<BasicContext> {
       context.body("world");
       Box::new(future::ok(context))
     };
@@ -77,7 +77,7 @@ fn optimized_bench_route_match(c: &mut Criterion) {
   c.bench_function("Optimized route match", |bench| {
     let mut app = App::<Request, BasicContext>::new_basic();
 
-    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> MiddlewareReturnValue<BasicContext> {
+    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send) -> MiddlewareReturnValue<BasicContext> {
       context.body("world");
       Box::new(future::ok(context))
     };
@@ -99,7 +99,7 @@ fn bench_route_match_with_param(c: &mut Criterion) {
   c.bench_function("Route match with route params", |bench| {
     let mut app = App::<Request, BasicContext>::new_basic();
 
-    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> MiddlewareReturnValue<BasicContext> {
+    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send) -> MiddlewareReturnValue<BasicContext> {
       let body = &context.params.get("hello").unwrap().clone();
       context.body(body);
       Box::new(future::ok(context))
@@ -121,7 +121,7 @@ fn bench_route_match_with_query_param(c: &mut Criterion) {
   c.bench_function("Route match with query params", |bench| {
     let mut app = App::<Request, BasicContext>::new_basic();
 
-    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> MiddlewareReturnValue<BasicContext> {
+    fn test_fn_1(mut context: BasicContext, _next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send) -> MiddlewareReturnValue<BasicContext> {
       let body = &context.query_params.get("hello").unwrap().clone();
       context.body(body);
       Box::new(future::ok(context))

--- a/thruster/examples/cookies/main.rs
+++ b/thruster/examples/cookies/main.rs
@@ -9,7 +9,7 @@ use thruster::thruster_middleware::cookies::CookieOptions;
 use thruster::server::Server;
 use thruster::ThrusterServer;
 
-fn plaintext(mut context: Ctx, _next: impl Fn(Ctx) -> MiddlewareReturnValue<Ctx>  + Send + Sync) -> MiddlewareReturnValue<Ctx> {
+fn plaintext(mut context: Ctx, _next: impl Fn(Ctx) -> MiddlewareReturnValue<Ctx>  + Send) -> MiddlewareReturnValue<Ctx> {
   let val = "Hello, World!";
   context.body(val);
   context.cookie("SomeCookie", "Some Value!", &CookieOptions::default());
@@ -17,7 +17,7 @@ fn plaintext(mut context: Ctx, _next: impl Fn(Ctx) -> MiddlewareReturnValue<Ctx>
   Box::new(future::ok(context))
 }
 
-fn redirect(mut context: Ctx, _next: impl Fn(Ctx) -> MiddlewareReturnValue<Ctx>  + Send + Sync) -> MiddlewareReturnValue<Ctx> {
+fn redirect(mut context: Ctx, _next: impl Fn(Ctx) -> MiddlewareReturnValue<Ctx>  + Send) -> MiddlewareReturnValue<Ctx> {
   context.redirect("/plaintext");
 
   Box::new(future::ok(context))

--- a/thruster/examples/hello_world/main.rs
+++ b/thruster/examples/hello_world/main.rs
@@ -15,7 +15,7 @@ use thruster::server::Server;
 use thruster::ThrusterServer;
 use crate::context::{generate_context, Ctx};
 
-fn not_found_404(context: Ctx, _next: impl Fn(Ctx) -> MiddlewareReturnValue<Ctx>  + Send + Sync) -> MiddlewareReturnValue<Ctx> {
+fn not_found_404(context: Ctx, _next: impl Fn(Ctx) -> MiddlewareReturnValue<Ctx>  + Send) -> MiddlewareReturnValue<Ctx> {
   let mut context = Ctx::new(context);
 
   context.body = "<html>
@@ -31,7 +31,7 @@ fn not_found_404(context: Ctx, _next: impl Fn(Ctx) -> MiddlewareReturnValue<Ctx>
 struct JsonStruct<'a> {
   message: &'a str
 }
-fn json(mut context: Ctx, _next: impl Fn(Ctx) -> MiddlewareReturnValue<Ctx>  + Send + Sync) -> MiddlewareReturnValue<Ctx> {
+fn json(mut context: Ctx, _next: impl Fn(Ctx) -> MiddlewareReturnValue<Ctx>  + Send) -> MiddlewareReturnValue<Ctx> {
   let json = JsonStruct {
     message: "Hello, World!"
   };
@@ -44,7 +44,7 @@ fn json(mut context: Ctx, _next: impl Fn(Ctx) -> MiddlewareReturnValue<Ctx>  + S
   Box::new(future::ok(context))
 }
 
-fn plaintext(mut context: Ctx, _next: impl Fn(Ctx) -> MiddlewareReturnValue<Ctx>  + Send + Sync) -> MiddlewareReturnValue<Ctx> {
+fn plaintext(mut context: Ctx, _next: impl Fn(Ctx) -> MiddlewareReturnValue<Ctx>  + Send) -> MiddlewareReturnValue<Ctx> {
   let val = "Hello, World!".to_owned();
 
   context.body = val;

--- a/thruster/examples/hyper_most_basic.rs
+++ b/thruster/examples/hyper_most_basic.rs
@@ -10,7 +10,7 @@ use thruster::server::{Server};
 use thruster::hyper_server::{HyperServer};
 use thruster::thruster_context::basic_hyper_context::{generate_context, BasicHyperContext as Ctx, HyperRequest};
 
-fn plaintext(mut context: Ctx, _next: impl Fn(Ctx) -> MiddlewareReturnValue<Ctx>  + Send + Sync) -> MiddlewareReturnValue<Ctx> {
+fn plaintext(mut context: Ctx, _next: impl Fn(Ctx) -> MiddlewareReturnValue<Ctx>  + Send) -> MiddlewareReturnValue<Ctx> {
   let val = "Hello, World!".as_bytes().to_vec();
   context.set_body(val);
 

--- a/thruster/examples/hyper_most_basic_async.rs
+++ b/thruster/examples/hyper_most_basic_async.rs
@@ -1,0 +1,26 @@
+#![feature(async_await, proc_macro_hygiene)]
+extern crate thruster;
+
+use thruster::{MiddlewareNext, MiddlewareReturnValue};
+use thruster::{App, ThrusterServer};
+use thruster::hyper_server::{HyperServer};
+use thruster::thruster_context::basic_hyper_context::{generate_context, BasicHyperContext as Ctx, HyperRequest};
+use thruster::thruster_proc::{async_middleware, middleware_fn};
+use hyper::Body;
+
+#[middleware_fn]
+async fn plaintext(mut context: Ctx, _next: MiddlewareNext<Ctx>) -> Ctx {
+  let val = "Hello, World!";
+  context.body = Body::from(val);
+  context
+}
+
+fn main() {
+  println!("Starting server...");
+
+  let mut app = App::<HyperRequest, Ctx>::create(generate_context);
+  app.get("/plaintext", async_middleware!(Ctx, [plaintext]));
+
+  let server = HyperServer::new(app);
+  server.start("0.0.0.0", 4321);
+}

--- a/thruster/examples/most_basic.rs
+++ b/thruster/examples/most_basic.rs
@@ -9,7 +9,7 @@ use thruster::{App, BasicContext as Ctx, MiddlewareChain, MiddlewareReturnValue,
 use thruster::server::Server;
 use thruster::ThrusterServer;
 
-fn profiling(context: Ctx, next: impl Fn(Ctx) -> MiddlewareReturnValue<Ctx>  + Send + Sync) -> MiddlewareReturnValue<Ctx> {
+fn profiling(context: Ctx, next: impl Fn(Ctx) -> MiddlewareReturnValue<Ctx>  + Send) -> MiddlewareReturnValue<Ctx> {
   println!("[start] {} -- {}",
     context.request.method(),
     context.request.path());
@@ -26,7 +26,7 @@ fn profiling(context: Ctx, next: impl Fn(Ctx) -> MiddlewareReturnValue<Ctx>  + S
   Box::new(ctx_future)
 }
 
-fn plaintext(mut context: Ctx, _next: impl Fn(Ctx) -> MiddlewareReturnValue<Ctx>  + Send + Sync) -> MiddlewareReturnValue<Ctx> {
+fn plaintext(mut context: Ctx, _next: impl Fn(Ctx) -> MiddlewareReturnValue<Ctx>  + Send) -> MiddlewareReturnValue<Ctx> {
   let val = "Hello, World!";
   context.body(val);
 

--- a/thruster/examples/most_basic_async.rs
+++ b/thruster/examples/most_basic_async.rs
@@ -42,7 +42,7 @@ fn main() {
   let mut app = App::<Request, Ctx>::new_basic();
 
   // app.use_middleware("/", async_middleware!(Ctx, [profiling]));
-  app.get("/plaintext/:asd", async_middleware!(Ctx, [plaintext]));
+  app.get("/plaintext", async_middleware!(Ctx, [plaintext]));
   app.set404(async_middleware!(Ctx, [test_fn_404]));
 
   let server = Server::new(app);

--- a/thruster/examples/multicontext.rs
+++ b/thruster/examples/multicontext.rs
@@ -57,13 +57,13 @@ impl Into<BasicContext> for Ctx {
   }
 }
 
-fn log(context: BasicContext, next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send + Sync) -> MiddlewareReturnValue<BasicContext> {
+fn log(context: BasicContext, next: impl Fn(BasicContext) -> MiddlewareReturnValue<BasicContext>  + Send) -> MiddlewareReturnValue<BasicContext> {
   println!("[{}] {}", context.request.method(), context.request.path());
 
   next(context)
 }
 
-fn goodbye(mut context: Ctx, _next: impl Fn(Ctx) -> MiddlewareReturnValue<Ctx>  + Send + Sync) -> MiddlewareReturnValue<Ctx> {
+fn goodbye(mut context: Ctx, _next: impl Fn(Ctx) -> MiddlewareReturnValue<Ctx>  + Send) -> MiddlewareReturnValue<Ctx> {
   context.body = "Goodbye, world!".to_owned();
 
   Box::new(future::ok(context))

--- a/thruster/examples/query_params.rs
+++ b/thruster/examples/query_params.rs
@@ -9,7 +9,7 @@ use thruster::server::Server;
 use thruster::thruster_middleware::query_params::query_params;
 use thruster::ThrusterServer;
 
-fn plaintext(mut context: Ctx, _next: impl Fn(Ctx) -> MiddlewareReturnValue<Ctx>  + Send + Sync) -> MiddlewareReturnValue<Ctx> {
+fn plaintext(mut context: Ctx, _next: impl Fn(Ctx) -> MiddlewareReturnValue<Ctx>  + Send) -> MiddlewareReturnValue<Ctx> {
   let val = serde_json::to_string(&context.query_params).unwrap();
   context.body(&val);
 

--- a/thruster/src/integration_tests.rs
+++ b/thruster/src/integration_tests.rs
@@ -6,7 +6,7 @@ use thruster_core::{middleware};
 use thruster::testing;
 
 
-fn test_fn_1(mut context: Ctx, _next: impl Fn(Ctx) -> MiddlewareReturnValue<Ctx>  + Send + Sync) -> MiddlewareReturnValue<Ctx> {
+fn test_fn_1(mut context: Ctx, _next: impl Fn(Ctx) -> MiddlewareReturnValue<Ctx>  + Send) -> MiddlewareReturnValue<Ctx> {
   let body = &context.params.get("id").unwrap().clone();
 
   context.body(body);
@@ -14,7 +14,7 @@ fn test_fn_1(mut context: Ctx, _next: impl Fn(Ctx) -> MiddlewareReturnValue<Ctx>
   Box::new(future::ok(context))
 }
 
-fn test_fn_404(mut context: Ctx, _next: impl Fn(Ctx) -> MiddlewareReturnValue<Ctx>  + Send + Sync) -> MiddlewareReturnValue<Ctx> {
+fn test_fn_404(mut context: Ctx, _next: impl Fn(Ctx) -> MiddlewareReturnValue<Ctx>  + Send) -> MiddlewareReturnValue<Ctx> {
   context.body("404");
 
   Box::new(future::ok(context))
@@ -31,5 +31,6 @@ fn it_should_correctly_404_if_no_param_is_given() {
 
   let response = testing::get(&app, "/test");
 
+  println!("response.body: '{}'", response.body);
   assert!(response.body == "404");
 }

--- a/thruster/src/lib.rs
+++ b/thruster/src/lib.rs
@@ -21,7 +21,9 @@ pub use thruster_middleware;
 #[cfg(feature="hyper_server")]
 pub use thruster_server::hyper_server;
 
+#[cfg(not(feature="hyper_server"))]
 pub use thruster_server::server;
+
 pub use thruster_server::thruster_server::ThrusterServer;
 pub use thruster_context;
 pub use thruster_context::basic_context::BasicContext;


### PR DESCRIPTION
**Issue:** Responses with large amounts of data are pretty slow compared to Actix + Hyper.

**Solution:** There are a few factors in this, but most of them rely in how we're storing data to send as a response. This PR addresses a single concern where, in `BasicContext`, we were converting from `Vec<u8>` to `&[u8]` to `Vec<u8>` and back to `&[u8]`. This should remove the middle two steps.

**Future Work:** I'd like to be able to have `BasicContext` modify the response buffer on the fly rather than just when the response is collected. This should minimize the moving of bytes around, which takes about 18% of the computation right now according to the flame graph.

Should help #118.