### PR TITLE
Change name of `node.to_string` to not make clippy mad

### DIFF
--- a/publish_helper.sh
+++ b/publish_helper.sh
@@ -5,44 +5,44 @@ DIR=`pwd`;
 echo $DIR
 # Proc Macros
 cd $DIR/thruster-proc;
-cargo publish;
+cargo publish --allow-dirty;
 sleep 5;
 
 # Core async await
 cd $DIR/thruster-core-async-await;
-cargo publish;
+cargo publish --allow-dirty;
 sleep 5;
 
 # Core
 cd $DIR/thruster-core;
-cargo publish;
+cargo publish --allow-dirty;
 sleep 5;
 
 # Context
 cd $DIR/thruster-context;
-cargo publish;
+cargo publish --allow-dirty;
 sleep 5;
 
 # Middleware
 cd $DIR/thruster-middleware;
-cargo publish;
+cargo publish --allow-dirty;
 sleep 5;
 
 # Async await
 cd $DIR/thruster-async-await;
-cargo publish;
+cargo publish --allow-dirty;
 sleep 5;
 
 # App
 cd $DIR/thruster-app;
-cargo publish;
+cargo publish --allow-dirty;
 sleep 5;
 
 # Server
 cd $DIR/thruster-server;
-cargo publish;
+cargo publish --allow-dirty;
 sleep 5;
 
 # Thruster
 cd $DIR/thruster;
-cargo publish;
+cargo publish --allow-dirty;

--- a/thruster-core/src/route_tree/node.rs
+++ b/thruster-core/src/route_tree/node.rs
@@ -249,12 +249,12 @@ impl<T: 'static + Context + Send> Node<T> {
   ///   let mut app = App::create(generate_context);
   ///
   ///   app.get("/plaintext", middleware![plaintext]);
-  ///  println!("app: {}", app._route_parser.route_tree.root_node.to_string(""));
+  ///  println!("app: {}", app._route_parser.route_tree.root_node.tree_string(""));
   ///  for (route, middleware) in app._route_parser.route_tree.root_node.get_route_list() {
   ///    println!("{}: {}", route, middleware.len());
   ///  }
   /// ```
-  pub fn to_string(&self, indent: &str) -> String {
+  pub fn tree_string(&self, indent: &str) -> String {
     let mut in_progress = "".to_owned();
     let value = match self.param_key.clone() {
       Some(key) => format!(":{}", key),
@@ -269,11 +269,11 @@ impl<T: 'static + Context + Send> Node<T> {
       self.is_terminal_node);
 
     for child in self.children.values() {
-      in_progress = format!("{}{}", in_progress, child.to_string(&format!("{}  ", indent)));
+      in_progress = format!("{}{}", in_progress, child.tree_string(&format!("{}  ", indent)));
     }
 
     if let Some(wildcard_node) = &self.wildcard_node {
-      in_progress = format!("{}{}", in_progress, wildcard_node.to_string(&format!("{}  ", indent)));
+      in_progress = format!("{}{}", in_progress, wildcard_node.tree_string(&format!("{}  ", indent)));
     }
 
     in_progress


### PR DESCRIPTION
Can't use the default formatter and display because we need to recursively send down indentation information. This seemed like an easy hack around it.