### PR TITLE
feat: Move testing into an optional feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ fn main() {
 Thruster also supports async/await on nightly! Once you've installed nightly (`rustup install nightly`,) you can use async await support in thruster by enabling the `thruster_async_await` feature,
 
 ```toml
-thruster = { version = "=0.7.11", features = ["thruster_async_await"] }
+thruster = { version = "=0.7.12", features = ["thruster_async_await"] }
 ```
 
 The core parts that make the new async await code work is designating middleware functions with the `#[middleware_fn]` attribute (which marks the middleware so that it's compatible with the stable futures version that thruster is built on,) and then the `async_middleware!` macro in the actual routes.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,6 +2,10 @@
 
 Below you'll find a set of notes for migrating between versions. It should be noted that although the intent is to follow semantic versioning, until thruster is released in earnest (1.x), the second digit will be the one that dictates breaking changes.
 
+## 0.7.12
+
+While async_await is still not stable (a month or so to go!) this release disables testing by default since it's not yet supported in an async await format. In order to enable, add the feature `thruster_testing` to your crate configuration.
+
 ## 0.7.11
 
 This release adds support for SSL servers via the `thruster::ssl_server::SSLServer` package. The new `SSLServer` works much like the old thruster server, except with the addition of needing to set `cert` and, optionally, `cert_pass` on the server struct.

--- a/thruster-app/Cargo.toml
+++ b/thruster-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thruster-app"
-version = "0.7.11"
+version = "0.7.12"
 authors = ["Pete Mertz <peter.s.mertz@gmail.com>"]
 description = "The App portion of the thruster web framework"
 readme = "README.md"
@@ -16,6 +16,7 @@ debug = true
 
 [features]
 default = []
+thruster_testing = []
 hyper_server = []
 thruster_async_await = [
   "thruster-core/thruster_async_await",
@@ -33,8 +34,8 @@ bytes = "0.4"
 futures = "0.1.23"
 futures-preview = { package = "futures-preview", version = "0.3.0-alpha.17", features = ["compat"] }
 templatify = "0.2.3"
-thruster-async-await = { version = "=0.7.11", path = "../thruster-async-await", optional = true }
-thruster-context = { version = "=0.7.11", path = "../thruster-context" }
-thruster-core = { version = "=0.7.11", path = "../thruster-core" }
-thruster-middleware = { version = "=0.7.11", path = "../thruster-middleware" }
-thruster-proc = { version = "=0.7.11", path = "../thruster-proc", optional = true }
+thruster-async-await = { version = "=0.7.12", path = "../thruster-async-await", optional = true }
+thruster-context = { version = "=0.7.12", path = "../thruster-context" }
+thruster-core = { version = "=0.7.12", path = "../thruster-core" }
+thruster-middleware = { version = "=0.7.12", path = "../thruster-middleware" }
+thruster-proc = { version = "=0.7.12", path = "../thruster-proc", optional = true }

--- a/thruster-app/src/lib.rs
+++ b/thruster-app/src/lib.rs
@@ -5,4 +5,6 @@ extern crate templatify;
 #[macro_use] extern crate thruster_core;
 
 pub mod app;
+
+#[cfg(feature = "thruster_testing")]
 pub mod testing;

--- a/thruster-async-await/Cargo.toml
+++ b/thruster-async-await/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thruster-async-await"
-version = "0.7.11"
+version = "0.7.12"
 authors = ["Pete Mertz <peter.s.mertz@gmail.com>"]
 description = "An async await shim for the thruster web framework"
 readme = "README.md"
@@ -24,5 +24,5 @@ thruster_error_handling = [
 futures-legacy = { version = "0.1.23", package = "futures" }
 futures-preview = { version = "0.3.0-alpha.16", features = ["compat"] }
 futures-util = "0.2.1"
-thruster-core = { version = "=0.7.11", path = "../thruster-core" }
+thruster-core = { version = "=0.7.12", path = "../thruster-core" }
 tokio = { version = "0.1.20" }

--- a/thruster-context/Cargo.toml
+++ b/thruster-context/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thruster-context"
-version = "0.7.11"
+version = "0.7.12"
 authors = ["Pete Mertz <peter.s.mertz@gmail.com>"]
 description = "The context portion of the thruster web framework"
 readme = "README.md"
@@ -25,5 +25,5 @@ thruster_error_handling = [
 
 [dependencies]
 hyper = { version = "0.12.25", optional = true }
-thruster-core = { version = "=0.7.11", path = "../thruster-core" }
-thruster-middleware = { version = "=0.7.11", path = "../thruster-middleware" }
+thruster-core = { version = "=0.7.12", path = "../thruster-core" }
+thruster-middleware = { version = "=0.7.12", path = "../thruster-middleware" }

--- a/thruster-core-async-await/Cargo.toml
+++ b/thruster-core-async-await/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thruster-core-async-await"
-version = "0.7.11"
+version = "0.7.12"
 authors = ["Pete Mertz <peter.s.mertz@gmail.com>"]
 description = "An async await shim for the core features of the thruster web framework"
 readme = "README.md"

--- a/thruster-core/Cargo.toml
+++ b/thruster-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thruster-core"
-version = "0.7.11"
+version = "0.7.12"
 authors = ["Pete Mertz <peter.s.mertz@gmail.com>"]
 description = "The core pieces of the thruster web framework"
 readme = "README.md"
@@ -33,4 +33,4 @@ templatify = "0.2.3"
 time = "0.1"
 tokio-codec = { version = "0.1.1" }
 tokio-io = { version = "0.1.12" }
-thruster-core-async-await = { version = "=0.7.11", path = "../thruster-core-async-await", optional = true }
+thruster-core-async-await = { version = "=0.7.12", path = "../thruster-core-async-await", optional = true }

--- a/thruster-middleware/Cargo.toml
+++ b/thruster-middleware/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thruster-middleware"
-version = "0.7.11"
+version = "0.7.12"
 authors = ["Pete Mertz <peter.s.mertz@gmail.com>"]
 description = "The middleware for the thruster web framework"
 readme = "README.md"
@@ -22,4 +22,4 @@ net2 = "0.2"
 num_cpus = "1.0"
 tokio = { version = "0.1.20" }
 tokio-codec = { version = "0.1.1" }
-thruster-core = { version = "=0.7.11", path = "../thruster-core" }
+thruster-core = { version = "=0.7.12", path = "../thruster-core" }

--- a/thruster-proc/Cargo.toml
+++ b/thruster-proc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thruster-proc"
-version = "0.7.11"
+version = "0.7.12"
 authors = ["Pete Mertz <peter.s.mertz@gmail.com>"]
 description = "The proc macros behind the thruster web framework"
 readme = "README.md"

--- a/thruster-server/Cargo.toml
+++ b/thruster-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thruster-server"
-version = "0.7.11"
+version = "0.7.12"
 authors = ["Pete Mertz <peter.s.mertz@gmail.com>"]
 description = "The core future wrappers aroun the thruster web framework"
 readme = "README.md"
@@ -29,7 +29,7 @@ num_cpus = "1.0"
 tokio = { version = "0.1" }
 tokio-tls = { version = "0.2" }
 native-tls = "0.2"
-thruster-core = { version = "=0.7.11", path = "../thruster-core" }
-thruster-app = { version = "=0.7.11", path = "../thruster-app" }
-thruster-context = { version = "=0.7.11", path = "../thruster-context" }
+thruster-core = { version = "=0.7.12", path = "../thruster-core" }
+thruster-app = { version = "=0.7.12", path = "../thruster-app" }
+thruster-context = { version = "=0.7.12", path = "../thruster-context" }
 

--- a/thruster/Cargo.toml
+++ b/thruster/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thruster"
-version = "0.7.11"
+version = "0.7.12"
 authors = ["Pete Mertz <peter.s.mertz@gmail.com>"]
 description = "A middleware based http async web server."
 readme = "README.md"
@@ -54,6 +54,9 @@ hyper_server = [
   "thruster-app/hyper_server",
   "thruster-server/hyper_server"
 ]
+thruster_testing = [
+  "thruster-app/thruster_testing"
+]
 thruster_async_await = [
   "thruster-proc",
   "thruster-app/thruster_async_await",
@@ -68,12 +71,12 @@ thruster_error_handling = [
 
 [dependencies]
 hyper = { version = "0.12.25", optional = true }
-thruster-app = { version = "=0.7.11", path = "../thruster-app" }
-thruster-context = { version = "=0.7.11", path = "../thruster-context" }
-thruster-core = { version = "=0.7.11", path = "../thruster-core" }
-thruster-middleware = { version = "=0.7.11", path = "../thruster-middleware" }
-thruster-proc = { version = "=0.7.11", path = "../thruster-proc", optional = true }
-thruster-server = { version = "=0.7.11", path = "../thruster-server" }
+thruster-app = { version = "=0.7.12", path = "../thruster-app" }
+thruster-context = { version = "=0.7.12", path = "../thruster-context" }
+thruster-core = { version = "=0.7.12", path = "../thruster-core" }
+thruster-middleware = { version = "=0.7.12", path = "../thruster-middleware" }
+thruster-proc = { version = "=0.7.12", path = "../thruster-proc", optional = true }
+thruster-server = { version = "=0.7.12", path = "../thruster-server" }
 
 [dev-dependencies]
 bytes = "0.4"

--- a/thruster/src/lib.rs
+++ b/thruster/src/lib.rs
@@ -1,4 +1,5 @@
 pub use thruster_app::app::App;
+#[cfg(feature = "thruster_testing")]
 pub use thruster_app::testing;
 
 pub use thruster_core::context::Context;


### PR DESCRIPTION
Unfortunately, testing is not well supported for the async await case yet. This will make testing optional rather than adding another separate crate to support testing in async await.

Normally it would be worth taking the time to separate the crate out so testing is still usable, but with the impending stabilization of async await, I think this makes more sense for the time being.