### PR TITLE
Actually use method parameter in thruster_testing::request

### DIFF
--- a/thruster-app/src/testing.rs
+++ b/thruster-app/src/testing.rs
@@ -23,7 +23,7 @@ pub fn request<T: Context<Response = Response> + Send>(app: &App<Request, T>, me
 
 
   let request = decode(&mut bytes).unwrap().unwrap();
-  let matched_route = app.resolve_from_method_and_path("GET", route);
+  let matched_route = app.resolve_from_method_and_path(method, route);
   let response = app.resolve(request, matched_route).wait().unwrap();
 
   TestResponse::new(response)


### PR DESCRIPTION
Related to https://github.com/trezm/Thruster/issues/126

The generic `request` method available in the thruster_testing module is the only way to perform a test request and pass custom headers to it. It allows the developer to pass the HTTP method as a string, but when resolving the route it used a hardcoded `"GET"` instead of the user-supplied method.

This PR fixes it.