### PR TITLE
bug: Fix subapp wildcard conflict issue

### DIFF
--- a/ROUTE_RESOLUTION.md
+++ b/ROUTE_RESOLUTION.md
@@ -1,0 +1,33 @@
+# Route Resolution Algorithm
+
+The route resolution algorithm should be fairly clear. It goes like this:
+
+### Construction
+1. Remove query params, attach to the request object (or somewhere accessible for later)
+1. Break a route down by slashes, you now have a list of components
+1. Add into a tree, treating `*` and `:param` as wild cards
+ex. `get("/a/b")` and `get(":id")` should make a tree like this
+
+```
+root (/)
+|\
+| \
+a  *
+|
+|
+b
+```
+
+### Resolution
+1. Split the incoming route in the same way as during construction
+1. Set `current_node = root`
+1. If `split.get(0)` does not exist, you're done, return the accumulated middleware
+1. Check if the first piece (`split.get(0)`) matches `current_node`
+    1. If it does
+        1. Set `current_node = child`
+        1. Accumulate any middleware attached to that node.
+    1. If it does not
+        1. Check if there is a wildcard node, if so then `current_node = current_node.wildcard`
+        1. If no wildcard, then the route isn't found, call the 404 handler.
+1. Remove the first piece of the split (or increment index)
+1. Go back to 3

--- a/thruster-core/src/route_tree/node.rs
+++ b/thruster-core/src/route_tree/node.rs
@@ -141,19 +141,19 @@ impl<T: 'static + Context + Send> Node<T> {
                 if let Some(wildcard_node) = &subtree.wildcard_node {
                     if wildcard_node.param_key.is_some() {
                         if let Some(ref mut existing_wildcard) = self.wildcard_node {
-                            for (key, child) in subtree.children.drain() {
-                                existing_wildcard.children.insert(key, child);
+                            for (key, child) in &wildcard_node.children {
+                                existing_wildcard.children.insert(key.to_string(), child.clone());
                             }
 
                             existing_wildcard.param_key = wildcard_node.param_key.clone();
                             existing_wildcard.is_terminal_node = existing_wildcard.is_terminal_node
                                 || wildcard_node.is_terminal_node;
                         }
-                    } else {
-                        for (key, child) in subtree.children.drain() {
-                            self.children.insert(key, child);
-                        }
                     }
+                }
+
+                for (key, child) in subtree.children.drain() {
+                    self.children.insert(key, child);
                 }
 
                 self.wildcard_node = subtree.wildcard_node;


### PR DESCRIPTION
There is an issue when adding a subapp with a wildcard wherein sibling routes are not properly propagated to the new tree. This means that having these routes:

`/:id`
`/do-something`

makes only `/:id` propagate correctly. This PR fixes that by always propagating sibling routes regardless of the presence of a wildcard.