### PR TITLE
feat: Add unix hyper server

### DIFF
--- a/thruster/Cargo.toml
+++ b/thruster/Cargo.toml
@@ -43,6 +43,10 @@ required-features = []
 name = "static_file"
 required-features = ["hyper_server", "file"]
 
+[[example]]
+name = "unix_socket"
+required-features = ["unix_hyper_server"]
+
 [[bench]]
 name = "app"
 harness = false
@@ -56,6 +60,10 @@ default = []
 hyper_server = [
   "hyper",
 ]
+unix_hyper_server = [
+  "hyper_server",
+  "hyperlocal",
+]
 tls = [
   "native-tls",
   "tokio-tls",
@@ -66,6 +74,7 @@ file = [
 
 [dependencies]
 async-trait = "0.1"
+hyperlocal = { version = "0.7.0", optional = true }
 hyper = { version = "0.13.1", optional = true }
 thruster-proc = "=0.9.0-alpha.7"
 bytes = "0.5.4"

--- a/thruster/examples/unix_socket.rs
+++ b/thruster/examples/unix_socket.rs
@@ -1,0 +1,27 @@
+use hyper::Body;
+use log::info;
+use thruster::context::basic_hyper_context::{
+    generate_context, BasicHyperContext as Ctx, HyperRequest,
+};
+use thruster::unix_hyper_server::UnixHyperServer;
+use thruster::{async_middleware, middleware_fn};
+use thruster::{App, ThrusterServer};
+use thruster::{MiddlewareNext, MiddlewareResult};
+
+#[middleware_fn]
+async fn plaintext(mut context: Ctx, _next: MiddlewareNext<Ctx>) -> MiddlewareResult<Ctx> {
+    let val = "Hello, World!";
+    context.body = Body::from(val);
+    Ok(context)
+}
+
+fn main() {
+    env_logger::init();
+    info!("Starting server...");
+
+    let mut app = App::<HyperRequest, Ctx>::create(generate_context);
+    app.get("/plaintext", async_middleware!(Ctx, [plaintext]));
+
+
+    UnixHyperServer::new(app).start("/tmp/thruster.sock", 0);
+}

--- a/thruster/src/lib.rs
+++ b/thruster/src/lib.rs
@@ -28,6 +28,9 @@ pub use server::*;
 #[cfg(feature = "hyper_server")]
 pub use server::hyper_server;
 
+#[cfg(feature = "unix_hyper_server")]
+pub use server::unix_hyper_server;
+
 #[cfg(all(feature = "hyper_server", feature = "tls"))]
 pub use server::ssl_hyper_server;
 

--- a/thruster/src/server/mod.rs
+++ b/thruster/src/server/mod.rs
@@ -7,6 +7,9 @@ pub mod ssl_server;
 #[cfg(feature = "hyper_server")]
 pub mod hyper_server;
 
+#[cfg(feature = "unix_hyper_server")]
+pub mod unix_hyper_server;
+
 #[cfg(all(feature = "hyper_server", feature = "tls"))]
 pub mod ssl_hyper_server;
 
@@ -19,6 +22,9 @@ pub use crate::ssl_server::SSLServer;
 
 #[cfg(feature = "hyper_server")]
 pub use crate::hyper_server::HyperServer;
+
+#[cfg(feautre = "unix_hyper_server")]
+pub use crate::unix_hyper_server::UnixHyperServer;
 
 #[cfg(all(feature = "hyper_server", feature = "tls"))]
 pub use crate::ssl_hyper_server::SSLHyperServer;

--- a/thruster/src/server/unix_hyper_server.rs
+++ b/thruster/src/server/unix_hyper_server.rs
@@ -1,0 +1,64 @@
+use std::{fs, path::Path};
+
+use async_trait::async_trait;
+use hyper::service::{make_service_fn, service_fn};
+use hyper::{Body, Request, Response, Server};
+use std::sync::Arc;
+use hyperlocal::UnixServerExt;
+
+use crate::app::App;
+use crate::context::basic_hyper_context::HyperRequest;
+use crate::core::context::Context;
+use crate::server::ThrusterServer;
+
+pub struct UnixHyperServer<T: 'static + Context + Send> {
+    app: App<HyperRequest, T>,
+}
+
+impl<T: 'static + Context + Send> UnixHyperServer<T> {}
+
+#[async_trait]
+impl<T: Context<Response = Response<Body>> + Send> ThrusterServer for UnixHyperServer<T> {
+    type Context = T;
+    type Response = Response<Body>;
+    type Request = HyperRequest;
+
+    fn new(app: App<Self::Request, T>) -> Self {
+        UnixHyperServer { app }
+    }
+
+    async fn build(mut self, socket_path: &str, _unused_port: u16) {
+        self.app._route_parser.optimize();
+
+        let arc_app = Arc::new(self.app);
+        let path = Path::new(socket_path);
+
+        if path.exists() {
+            fs::remove_file(path).expect(&format!("Could not remove file: {}", socket_path));
+        }
+
+        async move {
+            let service = make_service_fn(|_| {
+                let app = arc_app.clone();
+
+                async {
+                    Ok::<_, hyper::Error>(service_fn(move |req: Request<Body>| {
+                        let matched = app.resolve_from_method_and_path(
+                            &req.method().to_string(),
+                            &req.uri().to_string(),
+                        );
+
+                        let req = HyperRequest::new(req);
+                        app.resolve(req, matched)
+                    }))
+                }
+            });
+
+            Server::bind_unix(path).unwrap().serve(service).await?;
+
+            Ok::<_, hyper::Error>(())
+        }
+        .await
+        .expect("hyper server failed");
+    }
+}


### PR DESCRIPTION
Adds a new server, `UnixHyperServer` that allows users to use local Unix sockets. Resolves [#147](https://github.com/trezm/Thruster/issues/147)